### PR TITLE
Allow extensions provide custom reason text.

### DIFF
--- a/Sources/KituraContracts/Contracts.swift
+++ b/Sources/KituraContracts/Contracts.swift
@@ -56,6 +56,12 @@ public struct RequestError: RawRepresentable, Equatable, Hashable, Comparable, E
         self.init(rawValue: httpCode, reason: reason)
     }
 
+    /// Creates an error representing a HTTP status code.
+    /// - Parameter httpCode: a standard HTTP status code
+    public init(httpCode: Int) {
+        self.init(rawValue: httpCode)
+    }
+
     // MARK: Accessing information about the error type
 
     /// An error code representing the type of error that has occurred.
@@ -83,7 +89,7 @@ public struct RequestError: RawRepresentable, Equatable, Hashable, Comparable, E
 
     /// Indicates whether two URLs are the same.
     public static func ==(lhs: RequestError, rhs: RequestError) -> Bool {
-        return lhs.rawValue == rhs.rawValue
+        return (lhs.rawValue == rhs.rawValue && lhs.reason == rhs.reason)
     }
 
     // MARK: Describing a RequestError
@@ -95,7 +101,8 @@ public struct RequestError: RawRepresentable, Equatable, Hashable, Comparable, E
 
     /// The computed hash value for the error.
     public var hashValue: Int {
-        return rawValue
+        let str = reason + String(rawValue)
+        return str.hashValue
     }
 
     // MARK: Accessing constants representing HTTP status codes

--- a/Sources/KituraContracts/Contracts.swift
+++ b/Sources/KituraContracts/Contracts.swift
@@ -49,14 +49,7 @@ public struct RequestError: RawRepresentable, Equatable, Hashable, Comparable, E
         self.reason = reason
     }
 
-    /// Creates an error representing a HTTP status code.
-    /// - Parameter httpCode: a standard HTTP status code
-    public init(httpCode: Int) {
-        self.rawValue = httpCode
-        self.reason = RequestError.reason(forHTTPCode: httpCode)
-    }
-
-    // MARK: Accessing information about the error type
+    // MARK: Accessing information about the error.
 
     /// An error code representing the type of error that has occurred.
     /// The range of error codes from 100 up to 599 are reserved for HTTP status codes.
@@ -65,14 +58,6 @@ public struct RequestError: RawRepresentable, Equatable, Hashable, Comparable, E
 
     /// A human-readable description of the error code.
     public let reason: String
-
-    /// The HTTP status code for the error.
-    /// This value should be a valid HTTP status code if inside the range 100 to 599,
-    /// however, it may take a value outside that range when representing other types
-    /// of error.
-    public var httpCode: Int {
-        return rawValue
-    }
 
     // MARK: Comparing RequestErrors
 
@@ -88,15 +73,36 @@ public struct RequestError: RawRepresentable, Equatable, Hashable, Comparable, E
 
     // MARK: Describing a RequestError
 
-    /// A textual description of the error containing the error code and reason.
+    /// A textual description of the RequestError instance containing the error code and reason.
     public var description: String {
         return "\(rawValue) : \(reason)"
     }
 
-    /// The computed hash value for the error.
+    /// The computed hash value for the RequestError instance.
     public var hashValue: Int {
         let str = reason + String(rawValue)
         return str.hashValue
+    }
+}
+
+/**
+ Extends `RequestError` to provide HTTP specific error code and reason values.
+ */
+public extension RequestError {
+
+    /// The HTTP status code for the error.
+    /// This value should be a valid HTTP status code if inside the range 100 to 599,
+    /// however, it may take a value outside that range when representing other types
+    /// of error.
+    public var httpCode: Int {
+        return rawValue
+    }
+
+    /// Creates an error representing a HTTP status code.
+    /// - Parameter httpCode: a standard HTTP status code
+    public init(httpCode: Int) {
+        self.rawValue = httpCode
+        self.reason = RequestError.reason(forHTTPCode: httpCode)
     }
 
     // MARK: Accessing constants representing HTTP status codes

--- a/Sources/KituraContracts/Contracts.swift
+++ b/Sources/KituraContracts/Contracts.swift
@@ -51,15 +51,9 @@ public struct RequestError: RawRepresentable, Equatable, Hashable, Comparable, E
 
     /// Creates an error representing a HTTP status code.
     /// - Parameter httpCode: a standard HTTP status code
-    /// - Parameter reason: a textual representation of the HTTTP status code.
-    public init(httpCode: Int, reason: String) {
-        self.init(rawValue: httpCode, reason: reason)
-    }
-
-    /// Creates an error representing a HTTP status code.
-    /// - Parameter httpCode: a standard HTTP status code
     public init(httpCode: Int) {
-        self.init(rawValue: httpCode)
+        self.rawValue = httpCode
+        self.reason = RequestError.reason(forHTTPCode: httpCode)
     }
 
     // MARK: Accessing information about the error type
@@ -107,121 +101,185 @@ public struct RequestError: RawRepresentable, Equatable, Hashable, Comparable, E
 
     // MARK: Accessing constants representing HTTP status codes
     /// HTTP code 100 - Continue
-    public static let `continue` = RequestError(httpCode: 100, reason: "Continue")
+    public static let `continue` = RequestError(httpCode: 100)
     /// HTTP code 101 - Switching Protocols
-    public static let switchingProtocols = RequestError(httpCode: 101, reason: "Switching Protocols")
+    public static let switchingProtocols = RequestError(httpCode: 101)
     /// HTTP code 200 - OK
-    public static let ok = RequestError(httpCode: 200, reason: "OK")
+    public static let ok = RequestError(httpCode: 200)
     /// HTTP code 201 - Created
-    public static let created = RequestError(httpCode: 201, reason: "Created")
+    public static let created = RequestError(httpCode: 201)
     /// HTTP code 202 - Accepted
-    public static let accepted = RequestError(httpCode: 202, reason: "Accepted")
+    public static let accepted = RequestError(httpCode: 202)
     /// HTTP code 203 - Non Authoritative Information
-    public static let nonAuthoritativeInformation = RequestError(httpCode: 203, reason: "Non-Authoritative Information")
+    public static let nonAuthoritativeInformation = RequestError(httpCode: 203)
     /// HTTP code 204 - No Content
-    public static let noContent = RequestError(httpCode: 204, reason: "No Content")
+    public static let noContent = RequestError(httpCode: 204)
     /// HTTP code 205 - Reset Content
-    public static let resetContent = RequestError(httpCode: 205, reason: "Reset Content")
+    public static let resetContent = RequestError(httpCode: 205)
     /// HTTP code 206 - Partial Content
-    public static let partialContent = RequestError(httpCode: 206, reason: "Partial Content")
+    public static let partialContent = RequestError(httpCode: 206)
     /// HTTP code 207 - Multi Status
-    public static let multiStatus = RequestError(httpCode: 207, reason: "Multi-Status")
+    public static let multiStatus = RequestError(httpCode: 207)
     /// HTTP code 208 - Already Reported
-    public static let alreadyReported = RequestError(httpCode: 208, reason: "Already Reported")
+    public static let alreadyReported = RequestError(httpCode: 208)
     /// HTTP code 226 - IM Used
-    public static let imUsed = RequestError(httpCode: 226, reason: "IM Used")
-    /// HTTP code 300 - Multiple Choices           
-    public static let multipleChoices = RequestError(httpCode: 300, reason: "Multiple Choices")
+    public static let imUsed = RequestError(httpCode: 226)
+    /// HTTP code 300 - Multiple Choices
+    public static let multipleChoices = RequestError(httpCode: 300)
     /// HTTP code 301 - Moved Permanently
-    public static let movedPermanently = RequestError(httpCode: 301, reason: "Moved Permanently")
+    public static let movedPermanently = RequestError(httpCode: 301)
     /// HTTP code 302 - Found
-    public static let found = RequestError(httpCode: 302, reason: "Found")
+    public static let found = RequestError(httpCode: 302)
     /// HTTP code 303 - See Other
-    public static let seeOther = RequestError(httpCode: 303, reason: "See Other")
+    public static let seeOther = RequestError(httpCode: 303)
     /// HTTP code 304 - Not Modified
-    public static let notModified = RequestError(httpCode: 304, reason: "Not Modified")
+    public static let notModified = RequestError(httpCode: 304)
     /// HTTP code 305 - Use Proxy
-    public static let useProxy = RequestError(httpCode: 305, reason: "Use Proxy")
+    public static let useProxy = RequestError(httpCode: 305)
     /// HTTP code 307 - Temporary Redirect
-    public static let temporaryRedirect = RequestError(httpCode: 307, reason: "Temporary Redirect")
+    public static let temporaryRedirect = RequestError(httpCode: 307)
     /// HTTP code 308 - Permanent Redirect
-    public static let permanentRedirect = RequestError(httpCode: 308, reason: "Permanent Redirect")
+    public static let permanentRedirect = RequestError(httpCode: 308)
     /// HTTP code 400 - Bad Request
-    public static let badRequest = RequestError(httpCode: 400, reason: "Bad Request")
+    public static let badRequest = RequestError(httpCode: 400)
     /// HTTP code 401 - Unauthorized
-    public static let unauthorized = RequestError(httpCode: 401, reason: "Unauthorized")
+    public static let unauthorized = RequestError(httpCode: 401)
     /// HTTP code 402 - Payment Required
-    public static let paymentRequired = RequestError(httpCode: 402, reason: "Payment Required")
+    public static let paymentRequired = RequestError(httpCode: 402)
     /// HTTP code 403 - Forbidden
-    public static let forbidden = RequestError(httpCode: 403, reason: "Forbidden")
+    public static let forbidden = RequestError(httpCode: 403)
     /// HTTP code 404 - Not Found
-    public static let notFound = RequestError(httpCode: 404, reason: "Not Found")
+    public static let notFound = RequestError(httpCode: 404)
     /// HTTP code 405 - Method Not Allowed
-    public static let methodNotAllowed = RequestError(httpCode: 405, reason: "Method Not Allowed")
+    public static let methodNotAllowed = RequestError(httpCode: 405)
     /// HTTP code 406 - Not Acceptable
-    public static let notAcceptable = RequestError(httpCode: 406, reason: "Not Acceptable")
+    public static let notAcceptable = RequestError(httpCode: 406)
     /// HTTP code 407 - Proxy Authentication Required
-    public static let proxyAuthenticationRequired = RequestError(httpCode: 407, reason: "Proxy Authentication Required")
+    public static let proxyAuthenticationRequired = RequestError(httpCode: 407)
     /// HTTP code 408 - Request Timeout
-    public static let requestTimeout = RequestError(httpCode: 408, reason: "Request Timeout")
+    public static let requestTimeout = RequestError(httpCode: 408)
     /// HTTP code 409 - Conflict
-    public static let conflict = RequestError(httpCode: 409, reason: "Conflict")
+    public static let conflict = RequestError(httpCode: 409)
     /// HTTP code 410 - Gone
-    public static let gone = RequestError(httpCode: 410, reason: "Gone")
+    public static let gone = RequestError(httpCode: 410)
     /// HTTP code 411 - Length Required
-    public static let lengthRequired = RequestError(httpCode: 411, reason: "Length Required")
+    public static let lengthRequired = RequestError(httpCode: 411)
     /// HTTP code 412 - Precondition Failed
-    public static let preconditionFailed = RequestError(httpCode: 412, reason: "Precondition Failed")
+    public static let preconditionFailed = RequestError(httpCode: 412)
     /// HTTP code 413 - Payload Too Large
-    public static let payloadTooLarge = RequestError(httpCode: 413, reason: "Payload Too Large")
+    public static let payloadTooLarge = RequestError(httpCode: 413)
     /// HTTP code 414 - URI Too Long
-    public static let uriTooLong = RequestError(httpCode: 414, reason: "URI Too Long")
+    public static let uriTooLong = RequestError(httpCode: 414)
     /// HTTP code 415 - Unsupported Media Type
-    public static let unsupportedMediaType = RequestError(httpCode: 415, reason: "Unsupported Media Type")
+    public static let unsupportedMediaType = RequestError(httpCode: 415)
     /// HTTP code 416 - Range Not Satisfiable
-    public static let rangeNotSatisfiable = RequestError(httpCode: 416, reason: "Range Not Satisfiable")
+    public static let rangeNotSatisfiable = RequestError(httpCode: 416)
     /// HTTP code 417 - Expectation Failed
-    public static let expectationFailed = RequestError(httpCode: 417, reason: "Expectation Failed")
+    public static let expectationFailed = RequestError(httpCode: 417)
     /// HTTP code 421 - Misdirected Request
-    public static let misdirectedRequest = RequestError(httpCode: 421, reason: "Misdirected Request")
+    public static let misdirectedRequest = RequestError(httpCode: 421)
     /// HTTP code 422 - Unprocessable Entity
-    public static let unprocessableEntity = RequestError(httpCode: 422, reason: "Unprocessable Entity")
+    public static let unprocessableEntity = RequestError(httpCode: 422)
     /// HTTP code 423 - Locked
-    public static let locked = RequestError(httpCode: 423, reason: "Locked")
+    public static let locked = RequestError(httpCode: 423)
     /// HTTP code 424 - Failed Dependency
-    public static let failedDependency = RequestError(httpCode: 424, reason: "Failed Dependency")
+    public static let failedDependency = RequestError(httpCode: 424)
     /// HTTP code 426 - Upgrade Required
-    public static let upgradeRequired = RequestError(httpCode: 426, reason: "Upgrade Required")
+    public static let upgradeRequired = RequestError(httpCode: 426)
     /// HTTP code 428 - Precondition Required
-    public static let preconditionRequired = RequestError(httpCode: 428, reason: "Precondition Required")
+    public static let preconditionRequired = RequestError(httpCode: 428)
     /// HTTP code 429 - Too Many Requests
-    public static let tooManyRequests = RequestError(httpCode: 429, reason: "Too Many Requests")
+    public static let tooManyRequests = RequestError(httpCode: 429)
     /// HTTP code 431 - Request Header Fields Too Large
-    public static let requestHeaderFieldsTooLarge = RequestError(httpCode: 431, reason: "Request Header Fields Too Large")
+    public static let requestHeaderFieldsTooLarge = RequestError(httpCode: 431)
     /// HTTP code 451 - Unavailable For Legal Reasons
-    public static let unavailableForLegalReasons = RequestError(httpCode: 451, reason: "Unavailable For Legal Reasons")
+    public static let unavailableForLegalReasons = RequestError(httpCode: 451)
     /// HTTP code 500 - Internal Server Error
-    public static let internalServerError = RequestError(httpCode: 500, reason: "Internal Server Error")
+    public static let internalServerError = RequestError(httpCode: 500)
     /// HTTP code 501 - Not Implemented
-    public static let notImplemented = RequestError(httpCode: 501, reason: "Not Implemented")
+    public static let notImplemented = RequestError(httpCode: 501)
     /// HTTP code 502 - Bad Gateway
-    public static let badGateway = RequestError(httpCode: 502, reason: "Bad Gateway")
+    public static let badGateway = RequestError(httpCode: 502)
     /// HTTP code 503 - Service Unavailable
-    public static let serviceUnavailable = RequestError(httpCode: 503, reason: "Service Unavailable")
+    public static let serviceUnavailable = RequestError(httpCode: 503)
     /// HTTP code 504 - Gateway Timeout
-    public static let gatewayTimeout = RequestError(httpCode: 504, reason: "Gateway Timeout")
+    public static let gatewayTimeout = RequestError(httpCode: 504)
     /// HTTP code 505 - HTTP Version Not Supported
-    public static let httpVersionNotSupported = RequestError(httpCode: 505, reason: "HTTP Version Not Supported")
+    public static let httpVersionNotSupported = RequestError(httpCode: 505)
     /// HTTP code 506 - Variant Also Negotiates
-    public static let variantAlsoNegotiates = RequestError(httpCode: 506, reason: "Variant Also Negotiates")
+    public static let variantAlsoNegotiates = RequestError(httpCode: 506)
     /// HTTP code 507 - Insufficient Storage
-    public static let insufficientStorage = RequestError(httpCode: 507, reason: "Insufficient Storage")
+    public static let insufficientStorage = RequestError(httpCode: 507)
     /// HTTP code 508 - Loop Detected
-    public static let loopDetected = RequestError(httpCode: 508, reason: "Loop Detected")
+    public static let loopDetected = RequestError(httpCode: 508)
     /// HTTP code 510 - Not Extended
-    public static let notExtended = RequestError(httpCode: 510, reason: "Not Extended")
+    public static let notExtended = RequestError(httpCode: 510)
     /// HTTP code 511 - Network Authentication Required
-    public static let networkAuthenticationRequired = RequestError(httpCode: 511, reason: "Network Authentication Required")
+    public static let networkAuthenticationRequired = RequestError(httpCode: 511)
+
+    private static func reason(forHTTPCode code: Int) -> String {
+        switch code {
+            case 100: return "Continue"
+            case 101: return "Switching Protocols"
+            case 200: return "OK"
+            case 201: return "Created"
+            case 202: return "Accepted"
+            case 203: return "Non-Authoritative Information"
+            case 204: return "No Content"
+            case 205: return "Reset Content"
+            case 206: return "Partial Content"
+            case 207: return "Multi-Status"
+            case 208: return "Already Reported"
+            case 226: return "IM Used"
+            case 300: return "Multiple Choices"
+            case 301: return "Moved Permanently"
+            case 302: return "Found"
+            case 303: return "See Other"
+            case 304: return "Not Modified"
+            case 305: return "Use Proxy"
+            case 307: return "Temporary Redirect"
+            case 308: return "Permanent Redirect"
+            case 400: return "Bad Request"
+            case 401: return "Unauthorized"
+            case 402: return "Payment Required"
+            case 403: return "Forbidden"
+            case 404: return "Not Found"
+            case 405: return "Method Not Allowed"
+            case 406: return "Not Acceptable"
+            case 407: return "Proxy Authentication Required"
+            case 408: return "Request Timeout"
+            case 409: return "Conflict"
+            case 410: return "Gone"
+            case 411: return "Length Required"
+            case 412: return "Precondition Failed"
+            case 413: return "Payload Too Large"
+            case 414: return "URI Too Long"
+            case 415: return "Unsupported Media Type"
+            case 416: return "Range Not Satisfiable"
+            case 417: return "Expectation Failed"
+            case 421: return "Misdirected Request"
+            case 422: return "Unprocessable Entity"
+            case 423: return "Locked"
+            case 424: return "Failed Dependency"
+            case 426: return "Upgrade Required"
+            case 428: return "Precondition Required"
+            case 429: return "Too Many Requests"
+            case 431: return "Request Header Fields Too Large"
+            case 451: return "Unavailable For Legal Reasons"
+            case 500: return "Internal Server Error"
+            case 501: return "Not Implemented"
+            case 502: return "Bad Gateway"
+            case 503: return "Service Unavailable"
+            case 504: return "Gateway Timeout"
+            case 505: return "HTTP Version Not Supported"
+            case 506: return "Variant Also Negotiates"
+            case 507: return "Insufficient Storage"
+            case 508: return "Loop Detected"
+            case 510: return "Not Extended"
+            case 511: return "Network Authentication Required"
+            default: return "http_\(code)"
+        }
+    }
 }
 
 /**

--- a/Sources/KituraContracts/Contracts.swift
+++ b/Sources/KituraContracts/Contracts.swift
@@ -40,13 +40,20 @@ public struct RequestError: RawRepresentable, Equatable, Hashable, Comparable, E
     /// Creates an error representing the given error code.
     public init(rawValue: Int) {
         self.rawValue = rawValue
-        self.reason = RequestError.reason(forCode: rawValue)
+        self.reason = "error_\(rawValue)"
     }
 
-    /// Creates an error representing a HTTP status code
+    /// Creates an error representing the given error code and reason string.
+    public init(rawValue: Int, reason: String) {
+        self.rawValue = rawValue
+        self.reason = reason
+    }
+
+    /// Creates an error representing a HTTP status code.
     /// - Parameter httpCode: a standard HTTP status code
-    public init(httpCode: Int) {
-        self.init(rawValue: httpCode)
+    /// - Parameter reason: a textual representation of the HTTTP status code.
+    public init(httpCode: Int, reason: String) {
+        self.init(rawValue: httpCode, reason: reason)
     }
 
     // MARK: Accessing information about the error type
@@ -92,188 +99,122 @@ public struct RequestError: RawRepresentable, Equatable, Hashable, Comparable, E
     }
 
     // MARK: Accessing constants representing HTTP status codes
-
     /// HTTP code 100 - Continue
-    public static let `continue` = RequestError(httpCode: 100)
+    public static let `continue` = RequestError(httpCode: 100, reason: "Continue")
     /// HTTP code 101 - Switching Protocols
-    public static let switchingProtocols = RequestError(httpCode: 101)
+    public static let switchingProtocols = RequestError(httpCode: 101, reason: "Switching Protocols")
     /// HTTP code 200 - OK
-    public static let ok = RequestError(httpCode: 200)
+    public static let ok = RequestError(httpCode: 200, reason: "OK")
     /// HTTP code 201 - Created
-    public static let created = RequestError(httpCode: 201)
+    public static let created = RequestError(httpCode: 201, reason: "Created")
     /// HTTP code 202 - Accepted
-    public static let accepted = RequestError(httpCode: 202)
+    public static let accepted = RequestError(httpCode: 202, reason: "Accepted")
     /// HTTP code 203 - Non Authoritative Information
-    public static let nonAuthoritativeInformation = RequestError(httpCode: 203)
+    public static let nonAuthoritativeInformation = RequestError(httpCode: 203, reason: "Non-Authoritative Information")
     /// HTTP code 204 - No Content
-    public static let noContent = RequestError(httpCode: 204)
+    public static let noContent = RequestError(httpCode: 204, reason: "No Content")
     /// HTTP code 205 - Reset Content
-    public static let resetContent = RequestError(httpCode: 205)
+    public static let resetContent = RequestError(httpCode: 205, reason: "Reset Content")
     /// HTTP code 206 - Partial Content
-    public static let partialContent = RequestError(httpCode: 206)
+    public static let partialContent = RequestError(httpCode: 206, reason: "Partial Content")
     /// HTTP code 207 - Multi Status
-    public static let multiStatus = RequestError(httpCode: 207)
+    public static let multiStatus = RequestError(httpCode: 207, reason: "Multi-Status")
     /// HTTP code 208 - Already Reported
-    public static let alreadyReported = RequestError(httpCode: 208)
+    public static let alreadyReported = RequestError(httpCode: 208, reason: "Already Reported")
     /// HTTP code 226 - IM Used
-    public static let imUsed = RequestError(httpCode: 226)
-    /// HTTP code 300 - Multiple Choices
-    public static let multipleChoices = RequestError(httpCode: 300)
+    public static let imUsed = RequestError(httpCode: 226, reason: "IM Used")
+    /// HTTP code 300 - Multiple Choices           
+    public static let multipleChoices = RequestError(httpCode: 300, reason: "Multiple Choices")
     /// HTTP code 301 - Moved Permanently
-    public static let movedPermanently = RequestError(httpCode: 301)
+    public static let movedPermanently = RequestError(httpCode: 301, reason: "Moved Permanently")
     /// HTTP code 302 - Found
-    public static let found = RequestError(httpCode: 302)
+    public static let found = RequestError(httpCode: 302, reason: "Found")
     /// HTTP code 303 - See Other
-    public static let seeOther = RequestError(httpCode: 303)
+    public static let seeOther = RequestError(httpCode: 303, reason: "See Other")
     /// HTTP code 304 - Not Modified
-    public static let notModified = RequestError(httpCode: 304)
+    public static let notModified = RequestError(httpCode: 304, reason: "Not Modified")
     /// HTTP code 305 - Use Proxy
-    public static let useProxy = RequestError(httpCode: 305)
+    public static let useProxy = RequestError(httpCode: 305, reason: "Use Proxy")
     /// HTTP code 307 - Temporary Redirect
-    public static let temporaryRedirect = RequestError(httpCode: 307)
+    public static let temporaryRedirect = RequestError(httpCode: 307, reason: "Temporary Redirect")
     /// HTTP code 308 - Permanent Redirect
-    public static let permanentRedirect = RequestError(httpCode: 308)
+    public static let permanentRedirect = RequestError(httpCode: 308, reason: "Permanent Redirect")
     /// HTTP code 400 - Bad Request
-    public static let badRequest = RequestError(httpCode: 400)
+    public static let badRequest = RequestError(httpCode: 400, reason: "Bad Request")
     /// HTTP code 401 - Unauthorized
-    public static let unauthorized = RequestError(httpCode: 401)
+    public static let unauthorized = RequestError(httpCode: 401, reason: "Unauthorized")
     /// HTTP code 402 - Payment Required
-    public static let paymentRequired = RequestError(httpCode: 402)
+    public static let paymentRequired = RequestError(httpCode: 402, reason: "Payment Required")
     /// HTTP code 403 - Forbidden
-    public static let forbidden = RequestError(httpCode: 403)
+    public static let forbidden = RequestError(httpCode: 403, reason: "Forbidden")
     /// HTTP code 404 - Not Found
-    public static let notFound = RequestError(httpCode: 404)
+    public static let notFound = RequestError(httpCode: 404, reason: "Not Found")
     /// HTTP code 405 - Method Not Allowed
-    public static let methodNotAllowed = RequestError(httpCode: 405)
+    public static let methodNotAllowed = RequestError(httpCode: 405, reason: "Method Not Allowed")
     /// HTTP code 406 - Not Acceptable
-    public static let notAcceptable = RequestError(httpCode: 406)
+    public static let notAcceptable = RequestError(httpCode: 406, reason: "Not Acceptable")
     /// HTTP code 407 - Proxy Authentication Required
-    public static let proxyAuthenticationRequired = RequestError(httpCode: 407)
+    public static let proxyAuthenticationRequired = RequestError(httpCode: 407, reason: "Proxy Authentication Required")
     /// HTTP code 408 - Request Timeout
-    public static let requestTimeout = RequestError(httpCode: 408)
+    public static let requestTimeout = RequestError(httpCode: 408, reason: "Request Timeout")
     /// HTTP code 409 - Conflict
-    public static let conflict = RequestError(httpCode: 409)
+    public static let conflict = RequestError(httpCode: 409, reason: "Conflict")
     /// HTTP code 410 - Gone
-    public static let gone = RequestError(httpCode: 410)
+    public static let gone = RequestError(httpCode: 410, reason: "Gone")
     /// HTTP code 411 - Length Required
-    public static let lengthRequired = RequestError(httpCode: 411)
+    public static let lengthRequired = RequestError(httpCode: 411, reason: "Length Required")
     /// HTTP code 412 - Precondition Failed
-    public static let preconditionFailed = RequestError(httpCode: 412)
+    public static let preconditionFailed = RequestError(httpCode: 412, reason: "Precondition Failed")
     /// HTTP code 413 - Payload Too Large
-    public static let payloadTooLarge = RequestError(httpCode: 413)
+    public static let payloadTooLarge = RequestError(httpCode: 413, reason: "Payload Too Large")
     /// HTTP code 414 - URI Too Long
-    public static let uriTooLong = RequestError(httpCode: 414)
+    public static let uriTooLong = RequestError(httpCode: 414, reason: "URI Too Long")
     /// HTTP code 415 - Unsupported Media Type
-    public static let unsupportedMediaType = RequestError(httpCode: 415)
+    public static let unsupportedMediaType = RequestError(httpCode: 415, reason: "Unsupported Media Type")
     /// HTTP code 416 - Range Not Satisfiable
-    public static let rangeNotSatisfiable = RequestError(httpCode: 416)
+    public static let rangeNotSatisfiable = RequestError(httpCode: 416, reason: "Range Not Satisfiable")
     /// HTTP code 417 - Expectation Failed
-    public static let expectationFailed = RequestError(httpCode: 417)
+    public static let expectationFailed = RequestError(httpCode: 417, reason: "Expectation Failed")
     /// HTTP code 421 - Misdirected Request
-    public static let misdirectedRequest = RequestError(httpCode: 421)
+    public static let misdirectedRequest = RequestError(httpCode: 421, reason: "Misdirected Request")
     /// HTTP code 422 - Unprocessable Entity
-    public static let unprocessableEntity = RequestError(httpCode: 422)
+    public static let unprocessableEntity = RequestError(httpCode: 422, reason: "Unprocessable Entity")
     /// HTTP code 423 - Locked
-    public static let locked = RequestError(httpCode: 423)
+    public static let locked = RequestError(httpCode: 423, reason: "Locked")
     /// HTTP code 424 - Failed Dependency
-    public static let failedDependency = RequestError(httpCode: 424)
+    public static let failedDependency = RequestError(httpCode: 424, reason: "Failed Dependency")
     /// HTTP code 426 - Upgrade Required
-    public static let upgradeRequired = RequestError(httpCode: 426)
+    public static let upgradeRequired = RequestError(httpCode: 426, reason: "Upgrade Required")
     /// HTTP code 428 - Precondition Required
-    public static let preconditionRequired = RequestError(httpCode: 428)
+    public static let preconditionRequired = RequestError(httpCode: 428, reason: "Precondition Required")
     /// HTTP code 429 - Too Many Requests
-    public static let tooManyRequests = RequestError(httpCode: 429)
+    public static let tooManyRequests = RequestError(httpCode: 429, reason: "Too Many Requests")
     /// HTTP code 431 - Request Header Fields Too Large
-    public static let requestHeaderFieldsTooLarge = RequestError(httpCode: 431)
+    public static let requestHeaderFieldsTooLarge = RequestError(httpCode: 431, reason: "Request Header Fields Too Large")
     /// HTTP code 451 - Unavailable For Legal Reasons
-    public static let unavailableForLegalReasons = RequestError(httpCode: 451)
+    public static let unavailableForLegalReasons = RequestError(httpCode: 451, reason: "Unavailable For Legal Reasons")
     /// HTTP code 500 - Internal Server Error
-    public static let internalServerError = RequestError(httpCode: 500)
+    public static let internalServerError = RequestError(httpCode: 500, reason: "Internal Server Error")
     /// HTTP code 501 - Not Implemented
-    public static let notImplemented = RequestError(httpCode: 501)
+    public static let notImplemented = RequestError(httpCode: 501, reason: "Not Implemented")
     /// HTTP code 502 - Bad Gateway
-    public static let badGateway = RequestError(httpCode: 502)
+    public static let badGateway = RequestError(httpCode: 502, reason: "Bad Gateway")
     /// HTTP code 503 - Service Unavailable
-    public static let serviceUnavailable = RequestError(httpCode: 503)
+    public static let serviceUnavailable = RequestError(httpCode: 503, reason: "Service Unavailable")
     /// HTTP code 504 - Gateway Timeout
-    public static let gatewayTimeout = RequestError(httpCode: 504)
+    public static let gatewayTimeout = RequestError(httpCode: 504, reason: "Gateway Timeout")
     /// HTTP code 505 - HTTP Version Not Supported
-    public static let httpVersionNotSupported = RequestError(httpCode: 505)
+    public static let httpVersionNotSupported = RequestError(httpCode: 505, reason: "HTTP Version Not Supported")
     /// HTTP code 506 - Variant Also Negotiates
-    public static let variantAlsoNegotiates = RequestError(httpCode: 506)
+    public static let variantAlsoNegotiates = RequestError(httpCode: 506, reason: "Variant Also Negotiates")
     /// HTTP code 507 - Insufficient Storage
-    public static let insufficientStorage = RequestError(httpCode: 507)
+    public static let insufficientStorage = RequestError(httpCode: 507, reason: "Insufficient Storage")
     /// HTTP code 508 - Loop Detected
-    public static let loopDetected = RequestError(httpCode: 508)
+    public static let loopDetected = RequestError(httpCode: 508, reason: "Loop Detected")
     /// HTTP code 510 - Not Extended
-    public static let notExtended = RequestError(httpCode: 510)
+    public static let notExtended = RequestError(httpCode: 510, reason: "Not Extended")
     /// HTTP code 511 - Network Authentication Required
-    public static let networkAuthenticationRequired = RequestError(httpCode: 511)
-
-    private static func reason(forCode code: Int) -> String {
-        switch code {
-            case 100: return "Continue"
-            case 101: return "Switching Protocols"
-            case 200: return "OK"
-            case 201: return "Created"
-            case 202: return "Accepted"
-            case 203: return "Non-Authoritative Information"
-            case 204: return "No Content"
-            case 205: return "Reset Content"
-            case 206: return "Partial Content"
-            case 207: return "Multi-Status"
-            case 208: return "Already Reported"
-            case 226: return "IM Used"
-            case 300: return "Multiple Choices"
-            case 301: return "Moved Permanently"
-            case 302: return "Found"
-            case 303: return "See Other"
-            case 304: return "Not Modified"
-            case 305: return "Use Proxy"
-            case 307: return "Temporary Redirect"
-            case 308: return "Permanent Redirect"
-            case 400: return "Bad Request"
-            case 401: return "Unauthorized"
-            case 402: return "Payment Required"
-            case 403: return "Forbidden"
-            case 404: return "Not Found"
-            case 405: return "Method Not Allowed"
-            case 406: return "Not Acceptable"
-            case 407: return "Proxy Authentication Required"
-            case 408: return "Request Timeout"
-            case 409: return "Conflict"
-            case 410: return "Gone"
-            case 411: return "Length Required"
-            case 412: return "Precondition Failed"
-            case 413: return "Payload Too Large"
-            case 414: return "URI Too Long"
-            case 415: return "Unsupported Media Type"
-            case 416: return "Range Not Satisfiable"
-            case 417: return "Expectation Failed"
-            case 421: return "Misdirected Request"
-            case 422: return "Unprocessable Entity"
-            case 423: return "Locked"
-            case 424: return "Failed Dependency"
-            case 426: return "Upgrade Required"
-            case 428: return "Precondition Required"
-            case 429: return "Too Many Requests"
-            case 431: return "Request Header Fields Too Large"
-            case 451: return "Unavailable For Legal Reasons"
-            case 500: return "Internal Server Error"
-            case 501: return "Not Implemented"
-            case 502: return "Bad Gateway"
-            case 503: return "Service Unavailable"
-            case 504: return "Gateway Timeout"
-            case 505: return "HTTP Version Not Supported"
-            case 506: return "Variant Also Negotiates"
-            case 507: return "Insufficient Storage"
-            case 508: return "Loop Detected"
-            case 510: return "Not Extended"
-            case 511: return "Network Authentication Required"
-            default: return "http_\(code)"
-        }
-    }
-
+    public static let networkAuthenticationRequired = RequestError(httpCode: 511, reason: "Network Authentication Required")
 }
 
 /**

--- a/Tests/KituraContractsTests/KituraContractsTests.swift
+++ b/Tests/KituraContractsTests/KituraContractsTests.swift
@@ -71,11 +71,20 @@ class KituraContractsTests: XCTestCase {
         XCTAssertEqual("\(errorCode) : \(reason)", error.description)
 
         errorCode = 1500
-        reason = "http_\(errorCode)"
-        error = RequestError(httpCode: errorCode)
+        reason = "error_\(errorCode)"
+        error = RequestError(httpCode: errorCode, reason: reason)
         XCTAssertEqual(errorCode, error.rawValue)
         XCTAssertEqual(errorCode, error.httpCode)
         XCTAssertEqual(reason, error.reason)
         XCTAssertEqual("\(errorCode) : \(reason)", error.description)
+
+        error = RequestError.internalServerError
+        switch error {
+            case .internalServerError:
+                break
+            default:
+                XCTFail("Could not match error type in switch statement!")
+
+        }
      }
 }

--- a/Tests/KituraContractsTests/KituraContractsTests.swift
+++ b/Tests/KituraContractsTests/KituraContractsTests.swift
@@ -62,6 +62,7 @@ class KituraContractsTests: XCTestCase {
 //    }
 
     func testRequestError() {
+        // Test construction of error instances
         var errorCode = 500
         var reason = "Internal Server Error"
         var error = RequestError.internalServerError
@@ -72,19 +73,23 @@ class KituraContractsTests: XCTestCase {
 
         errorCode = 1500
         reason = "error_\(errorCode)"
-        error = RequestError(httpCode: errorCode, reason: reason)
+        error = RequestError(httpCode: errorCode)
         XCTAssertEqual(errorCode, error.rawValue)
         XCTAssertEqual(errorCode, error.httpCode)
         XCTAssertEqual(reason, error.reason)
         XCTAssertEqual("\(errorCode) : \(reason)", error.description)
 
+        // Test we can use switch statement on error instances
         error = RequestError.internalServerError
         switch error {
             case .internalServerError:
                 break
             default:
-                XCTFail("Could not match error type in switch statement!")
-
+                XCTFail("Could not match error type inside switch statement!")
         }
+
+        // Test equality
+        var anotherError = RequestError.internalServerError
+        XCTAssertEqual(error, anotherError)
      }
 }

--- a/Tests/KituraContractsTests/KituraContractsTests.swift
+++ b/Tests/KituraContractsTests/KituraContractsTests.swift
@@ -107,7 +107,7 @@ class KituraContractsTests: XCTestCase {
         }
 
         // Test equality
-        var anotherError = RequestError.internalServerError
+        let anotherError = RequestError.internalServerError
         XCTAssertEqual(error, anotherError)
      }
 }

--- a/Tests/KituraContractsTests/KituraContractsTests.swift
+++ b/Tests/KituraContractsTests/KituraContractsTests.swift
@@ -63,6 +63,7 @@ class KituraContractsTests: XCTestCase {
 
     func testRequestError() {
         // Test construction of error instances
+        // Test predefined instances of RequestError
         var errorCode = 500
         var reason = "Internal Server Error"
         var error = RequestError.internalServerError
@@ -71,8 +72,25 @@ class KituraContractsTests: XCTestCase {
         XCTAssertEqual(reason, error.reason)
         XCTAssertEqual("\(errorCode) : \(reason)", error.description)
 
+        // Test construction of custom RequestError for http codes
+        error = RequestError(httpCode: errorCode)
+        XCTAssertEqual(errorCode, error.rawValue)
+        XCTAssertEqual(errorCode, error.httpCode)
+        XCTAssertEqual(reason, error.reason)
+        XCTAssertEqual("\(errorCode) : \(reason)", error.description)
+
+        // Test construction of custom RequestError for raw codes
         errorCode = 1500
         reason = "error_\(errorCode)"
+        error = RequestError(rawValue: errorCode)
+        XCTAssertEqual(errorCode, error.rawValue)
+        XCTAssertEqual(errorCode, error.httpCode)
+        XCTAssertEqual(reason, error.reason)
+        XCTAssertEqual("\(errorCode) : \(reason)", error.description)
+
+        // Test construction of custom RequestError for unknown http codes
+        errorCode = 1500
+        reason = "http_\(errorCode)"
         error = RequestError(httpCode: errorCode)
         XCTAssertEqual(errorCode, error.rawValue)
         XCTAssertEqual(errorCode, error.httpCode)


### PR DESCRIPTION
Given the current structure of RequestError, developers who implement an extension for it cannot provide a custom reason text (because extensions cannot override existing functionality). I ran into this limitation this week as I was prototyping code for Cloud Functions.

As reference, see:

- https://github.com/rolivieri/functions-swift/blob/master/Sources/Action/RequestErrorExtension.swift#L5
- https://github.com/rolivieri/functions-swift/blob/master/Sources/Action/main.swift#L122

- https://github.com/rolivieri/functions-swift/blob/issue.request-error/Sources/Action/RequestErrorExtension.swift#L5
- https://github.com/rolivieri/functions-swift/blob/issue.request-error/Sources/Action/main.swift#L125