### PR TITLE
Add RequestError body codable

### DIFF
--- a/Sources/KituraContracts/BodyFormat.swift
+++ b/Sources/KituraContracts/BodyFormat.swift
@@ -1,0 +1,62 @@
+/**
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Foundation
+
+/**
+ A set of values representing the format of a response body.
+
+ This struct is intended to be "enum-like" and values should be
+ accessed via the public static stored properties.
+ 
+ - Note: An enum was not used here because currently enums are
+         always exhaustive. This means adding a case to an enum
+         is a breaking change. In order to keep such additions
+         non-breaking we have used an "enum-like" struct instead.
+         This means code using `BodyFormat` should always handle
+         unrecognised `BodyFormat` values (eg in a default case
+         of a switch). `UnsupportedBodyFormatError` may be used
+         in this situation.
+
+ ### Usage Example: ###
+ ````
+ let format = BodyFormat.json
+ ````
+ */
+public struct BodyFormat: Equatable {
+    public let type: String
+
+    private init(_ type: String) {
+        self.type = type
+    }
+
+    public static func == (_ lhs: BodyFormat, _ rhs: BodyFormat) -> Bool {
+        return lhs.type == rhs.type
+    }
+
+    public static let json = BodyFormat("application/json")
+}
+
+/**
+ An error that may be thrown when a particular instance of `BodyFormat`
+ is not supported
+ */
+public struct UnsupportedBodyFormatError: Error {
+    public let bodyFormat: BodyFormat
+    public init(_ bodyFormat: BodyFormat) {
+        self.bodyFormat = bodyFormat
+    }
+}

--- a/Sources/KituraContracts/BodyFormat.swift
+++ b/Sources/KituraContracts/BodyFormat.swift
@@ -21,7 +21,7 @@ import Foundation
 
  This struct is intended to be "enum-like" and values should be
  accessed via the public static stored properties.
- 
+
  - Note: An enum was not used here because currently enums are
          always exhaustive. This means adding a case to an enum
          is a breaking change. In order to keep such additions

--- a/Sources/KituraContracts/Contracts.swift
+++ b/Sources/KituraContracts/Contracts.swift
@@ -73,28 +73,41 @@ public struct RequestError: RawRepresentable, Equatable, Hashable, Comparable, E
     /// A human-readable description of the error code.
     public let reason: String
 
-    /// A type-erased Codable object describing the error
-    ///
-    /// Usage Example:
-    /// ```
-    ///     if let errorBody = error.body as? MyCodableObject {
-    ///         // Access full error information encoded in errorBody
-    ///     } else {
-    ///         // Handle unexpected type in error / fallback to less
-    ///         // specific error handling based only on error number
-    ///     }
-    /// ```
-    /// - Note: The code accessing this property is expected to know the
-    ///         concrete type of this object and downcast, handling any
-    ///         failures do to type-mismatch appropriately.
+    /**
+     A type-erased Codable object describing the error
+
+     ### Usage Example: ###
+     ````
+     if let errorBody = error.body as? MyCodableObject {
+         // Access full error information encoded in errorBody
+     } else {
+         // Handle unexpected type in error / fallback to less
+         // specific error handling based only on error number
+     }
+     ````
+     - Note: The code accessing this property is expected to know the
+             concrete type of this object and downcast, handling any
+             failures do to type-mismatch appropriately.
+     */
     public private(set) var body: Codable? = nil
 
-    /// A closure that encodes the `body` into a `Data` object in the
-    /// requested format
-    /// - parameter `Format` describes the format that should be used
-    ///             (for example: `Format.json`)
-    /// - returns the `Data` object or `nil` if `body` is `nil`
-    /// - throws an `EncodingError` if the encoding fails
+    /**
+     A closure that encodes the `body` into a `Data` object in the
+     requested format
+
+     ### Usage Example: ###
+     ```
+     if let errorbodyData = error.bodyData {
+         let data = try errorBodyData(.json)
+     }
+     ```
+     - parameter `BodyFormat` describes the format that should be used
+                 (for example: `BodyFormat.json`)
+     - returns the `Data` object or `nil` if `body` is `nil`
+     - throws an `EncodingError` if the encoding fails
+     - throws an `UnsupportedBodyFormatError` if the provided `BodyFormat`
+              is not supported
+     */
     public private(set) var bodyData: ((BodyFormat) throws -> Data)? = nil
 
     // MARK: Comparing RequestErrors

--- a/Sources/KituraContracts/Contracts.swift
+++ b/Sources/KituraContracts/Contracts.swift
@@ -14,6 +14,8 @@
  * limitations under the License.
  **/
 
+ import Foundation
+
 // MARK
 
 /**
@@ -34,6 +36,9 @@
  */
 public struct RequestError: RawRepresentable, Equatable, Hashable, Comparable, Error, CustomStringConvertible {
     public typealias RawValue = Int
+    public enum Format {
+        case json
+    }
 
     // MARK: Creating a RequestError from a numeric code
 
@@ -49,6 +54,16 @@ public struct RequestError: RawRepresentable, Equatable, Hashable, Comparable, E
         self.reason = reason
     }
 
+    public init<BodyType: Encodable>(_ base: RequestError, body: BodyType) {
+        self.rawValue = base.rawValue
+        self.reason = base.reason
+        self.bodyDataGenerator = { format in
+            switch format {
+                case .json: return try JSONEncoder().encode(body)
+            }
+        }
+    }
+
     // MARK: Accessing information about the error.
 
     /// An error code representing the type of error that has occurred.
@@ -58,6 +73,9 @@ public struct RequestError: RawRepresentable, Equatable, Hashable, Comparable, E
 
     /// A human-readable description of the error code.
     public let reason: String
+
+    /// A closure that stores an Encodable body describing the error.
+    public private(set) var bodyDataGenerator: ((Format) throws -> Data)? = nil
 
     // MARK: Comparing RequestErrors
 

--- a/Sources/KituraContracts/Contracts.swift
+++ b/Sources/KituraContracts/Contracts.swift
@@ -74,6 +74,9 @@ public struct RequestError: RawRepresentable, Equatable, Hashable, Comparable, E
 
     /// Creates an error respresenting the given base error, with a custom
     /// response body given as Data and a BodyFormat
+    ///
+    /// - throws an `UnsupportedBodyFormatError` if the provided `BodyFormat`
+    ///          is not supported
     public init(_ base: RequestError, bodyData: Data, format: BodyFormat) throws {
         self.rawValue = base.rawValue
         self.reason = base.reason

--- a/Sources/KituraContracts/Contracts.swift
+++ b/Sources/KituraContracts/Contracts.swift
@@ -36,9 +36,6 @@
  */
 public struct RequestError: RawRepresentable, Equatable, Hashable, Comparable, Error, CustomStringConvertible {
     public typealias RawValue = Int
-    public enum Format {
-        case json
-    }
 
     // MARK: Creating a RequestError from a numeric code
 
@@ -61,6 +58,7 @@ public struct RequestError: RawRepresentable, Equatable, Hashable, Comparable, E
         self.bodyData = { format in
             switch format {
                 case .json: return try JSONEncoder().encode(body)
+                default: throw UnsupportedBodyFormatError(format)
             }
         }
     }
@@ -97,17 +95,17 @@ public struct RequestError: RawRepresentable, Equatable, Hashable, Comparable, E
     ///             (for example: `Format.json`)
     /// - returns the `Data` object or `nil` if `body` is `nil`
     /// - throws an `EncodingError` if the encoding fails
-    public private(set) var bodyData: ((Format) throws -> Data)? = nil
+    public private(set) var bodyData: ((BodyFormat) throws -> Data)? = nil
 
     // MARK: Comparing RequestErrors
 
     /// Returns a Boolean value indicating whether the value of the first argument is less than that of the second argument.
-    public static func <(lhs: RequestError, rhs: RequestError) -> Bool {
+    public static func < (lhs: RequestError, rhs: RequestError) -> Bool {
         return lhs.rawValue < rhs.rawValue
     }
 
     /// Indicates whether two URLs are the same.
-    public static func ==(lhs: RequestError, rhs: RequestError) -> Bool {
+    public static func == (lhs: RequestError, rhs: RequestError) -> Bool {
         return (lhs.rawValue == rhs.rawValue && lhs.reason == rhs.reason)
     }
 

--- a/Sources/KituraContracts/Contracts.swift
+++ b/Sources/KituraContracts/Contracts.swift
@@ -51,6 +51,8 @@ public struct RequestError: RawRepresentable, Equatable, Hashable, Comparable, E
         self.reason = reason
     }
 
+    /// Creates an error respresenting the given base error and with a custom
+    /// response body
     public init<Body: Codable>(_ base: RequestError, body: Body) {
         self.rawValue = base.rawValue
         self.reason = base.reason

--- a/Sources/KituraContracts/Contracts.swift
+++ b/Sources/KituraContracts/Contracts.swift
@@ -127,7 +127,7 @@ public struct RequestError: RawRepresentable, Equatable, Hashable, Comparable, E
     private var bodyDataEncoder: ((BodyFormat) throws -> Data)? = nil
 
     /**
-     Returns the error body encoded into bytes in a given format (eg: JSON).
+     Returns the Codable error body encoded into bytes in a given format (eg: JSON).
 
      This function should be used if the RequestError was created using
      `init(_:body:)`, otherwise it will return `nil`.
@@ -160,7 +160,7 @@ public struct RequestError: RawRepresentable, Equatable, Hashable, Comparable, E
     }
 
     /**
-     Returns the error body as the requested `Codable` type.
+     Returns the Data error body as the requested `Codable` type.
 
      This function should be used if the RequestError was created using
      `init(_:bodyData:format:)`, otherwise it will return `nil`.
@@ -197,7 +197,7 @@ public struct RequestError: RawRepresentable, Equatable, Hashable, Comparable, E
     }
 
     /**
-     Returns the error body as the requested `Codable` type.
+     Returns the Data error body as the requested `Codable` type.
 
      This function should be used if the RequestError was created using
      `init(_:bodyData:format:)`, otherwise it will return `nil`.

--- a/Sources/KituraContracts/Contracts.swift
+++ b/Sources/KituraContracts/Contracts.swift
@@ -58,7 +58,7 @@ public struct RequestError: RawRepresentable, Equatable, Hashable, Comparable, E
         self.reason = reason
     }
 
-    /// Creates an error respresenting the given base error, with a custom
+    /// Creates an error representing the given base error, with a custom
     /// response body given as a Codable
     public init<Body: Codable>(_ base: RequestError, body: Body) {
         self.rawValue = base.rawValue

--- a/Sources/KituraContracts/Contracts.swift
+++ b/Sources/KituraContracts/Contracts.swift
@@ -90,7 +90,7 @@ public struct RequestError: RawRepresentable, Equatable, Hashable, Comparable, E
      ````
      - Note: The code accessing this property is expected to know the
              concrete type of this object and downcast, handling any
-             failures do to type-mismatch appropriately.
+             failures appropriately.
      */
     public private(set) var body: Codable? = nil
 

--- a/Sources/KituraContracts/Contracts.swift
+++ b/Sources/KituraContracts/Contracts.swift
@@ -51,7 +51,7 @@ public struct RequestError: RawRepresentable, Equatable, Hashable, Comparable, E
         self.reason = reason
     }
 
-    /// Creates an error respresenting the given base error and with a custom
+    /// Creates an error respresenting the given base error, with a custom
     /// response body
     public init<Body: Codable>(_ base: RequestError, body: Body) {
         self.rawValue = base.rawValue
@@ -76,7 +76,8 @@ public struct RequestError: RawRepresentable, Equatable, Hashable, Comparable, E
     public let reason: String
 
     /**
-     A type-erased Codable object describing the error
+     A (type-erased) Codable object representing the custom response body
+     for this error
 
      ### Usage Example: ###
      ````

--- a/Sources/KituraContracts/Contracts.swift
+++ b/Sources/KituraContracts/Contracts.swift
@@ -100,8 +100,9 @@ public struct RequestError: RawRepresentable, Equatable, Hashable, Comparable, E
 
      ### Usage Example: ###
      ```
-     if let errorbodyData = error.bodyData {
+     if let errorBodyData = error.bodyData {
          let data = try errorBodyData(.json)
+         ...
      }
      ```
      - parameter `BodyFormat` describes the format that should be used

--- a/Sources/KituraContracts/Contracts.swift
+++ b/Sources/KituraContracts/Contracts.swift
@@ -46,14 +46,12 @@ public struct RequestError: RawRepresentable, Equatable, Hashable, Comparable, E
     public init(rawValue: Int) {
         self.rawValue = rawValue
         self.reason = "error_\(rawValue)"
-        self.body = nil
     }
 
     /// Creates an error representing the given error code and reason string.
     public init(rawValue: Int, reason: String) {
         self.rawValue = rawValue
         self.reason = reason
-        self.body = nil
     }
 
     public init<Body: Codable>(_ base: RequestError, body: Body) {
@@ -91,7 +89,7 @@ public struct RequestError: RawRepresentable, Equatable, Hashable, Comparable, E
     /// - Note: The code accessing this property is expected to know the
     ///         concrete type of this object and downcast, handling any
     ///         failures do to type-mismatch appropriately.
-    public let body: Codable?
+    public private(set) var body: Codable? = nil
 
     /// A closure that encodes the `body` into a `Data` object in the
     /// requested format
@@ -145,7 +143,6 @@ public extension RequestError {
     public init(httpCode: Int) {
         self.rawValue = httpCode
         self.reason = RequestError.reason(forHTTPCode: httpCode)
-        self.body = nil
     }
 
     // MARK: Accessing constants representing HTTP status codes

--- a/Sources/KituraContracts/Contracts.swift
+++ b/Sources/KituraContracts/Contracts.swift
@@ -157,8 +157,8 @@ public struct RequestError: RawRepresentable, Equatable, Hashable, Comparable, E
          // Handle failure to decode
      }
      ```
-     - parameter `BodyFormat` describes the format that should be used
-                 (for example: `BodyFormat.json`)
+     - parameter the type of the value to decode from the body data
+                 (for example: `MyCodableType.self`)
      - returns the `Codable` object or `nil` if there is no body or if the
                error was not initialized with `init(_:bodyData:format:)`
      - throws a `DecodingError` if decoding fails

--- a/Tests/KituraContractsTests/KituraContractsTests.swift
+++ b/Tests/KituraContractsTests/KituraContractsTests.swift
@@ -97,6 +97,16 @@ class KituraContractsTests: XCTestCase {
         XCTAssertEqual(reason, error.reason)
         XCTAssertEqual("\(errorCode) : \(reason)", error.description)
 
+        // Test construction of custom RequestError with body
+        error = RequestError(.serviceUnavailable, body: Status(value: .BROKEN))
+        XCTAssertEqual(error.rawValue, RequestError.serviceUnavailable.rawValue)
+        XCTAssertEqual(error.rawValue, RequestError.serviceUnavailable.httpCode)
+        XCTAssertEqual(error.reason, RequestError.serviceUnavailable.reason)
+        XCTAssertNotNil(error.bodyDataGenerator)
+        if let bodyDataGenerator = error.bodyDataGenerator {
+            XCTAssertEqual(try? bodyDataGenerator(.json), try! JSONEncoder().encode(Status(value: .BROKEN)))
+        }
+
         // Test we can use switch statement on error instances
         error = RequestError.internalServerError
         switch error {

--- a/Tests/KituraContractsTests/KituraContractsTests.swift
+++ b/Tests/KituraContractsTests/KituraContractsTests.swift
@@ -105,8 +105,8 @@ class KituraContractsTests: XCTestCase {
         XCTAssertNotNil(error.body)
         XCTAssertNotNil(error.body as? Status)
         XCTAssertNotNil(error.bodyData)
-        if let bodyData = error.bodyData {
-            XCTAssertEqual(try? bodyData(.json), try! JSONEncoder().encode(Status(value: .BROKEN)))
+        if let bodyData = try? error.bodyData?(.json) {
+            XCTAssertEqual(bodyData, try JSONEncoder().encode(Status(value: .BROKEN)))
         }
 
         // Test we can use switch statement on error instances

--- a/Tests/KituraContractsTests/KituraContractsTests.swift
+++ b/Tests/KituraContractsTests/KituraContractsTests.swift
@@ -102,9 +102,11 @@ class KituraContractsTests: XCTestCase {
         XCTAssertEqual(error.rawValue, RequestError.serviceUnavailable.rawValue)
         XCTAssertEqual(error.rawValue, RequestError.serviceUnavailable.httpCode)
         XCTAssertEqual(error.reason, RequestError.serviceUnavailable.reason)
-        XCTAssertNotNil(error.bodyDataGenerator)
-        if let bodyDataGenerator = error.bodyDataGenerator {
-            XCTAssertEqual(try? bodyDataGenerator(.json), try! JSONEncoder().encode(Status(value: .BROKEN)))
+        XCTAssertNotNil(error.body)
+        XCTAssertNotNil(error.body as? Status)
+        XCTAssertNotNil(error.bodyData)
+        if let bodyData = error.bodyData {
+            XCTAssertEqual(try? bodyData(.json), try! JSONEncoder().encode(Status(value: .BROKEN)))
         }
 
         // Test we can use switch statement on error instances

--- a/Tests/KituraContractsTests/Models.swift
+++ b/Tests/KituraContractsTests/Models.swift
@@ -53,6 +53,18 @@ struct User: Codable {
     let name: String
 }
 
+struct Status: Codable, Equatable {
+    enum Value: String, Codable {
+        case OK
+        case BROKEN
+    }
+    let value: Value
+
+    public static func ==(lhs: Status, rhs: Status) -> Bool {
+        return lhs.value == rhs.value
+    }
+}
+
 //extension User: Persistable {
 //    public typealias Id = Int
 //}


### PR DESCRIPTION
Add the capability to provide a `Codable` object to `RequestError` that will be encoded and sent by the `Router` as the response body when passed to the completion handler of a codable route.

## Description
This PR is one part of a pair, this one is for `KituraContracts`, the other is for `Kitura` (https://github.com/IBM-Swift/Kitura/pull/1214).

**In this PR** we add a new generic constructor to `RequestError` that can specify a "base" request error and a body `Codable`, for example: `RequestError(.unavailable, body: health.status)`.

This will assign the object to a new stored property `body` as a (type-erased) `Codable`. The fact the type is erased allow the `RequestError` struct to remain non-generic (changing it to be generic would be a breaking change to the API).

However, this means that the real type of the `body` is no longer know. In order for the `Router` to encode the `body` into `Data` in some format (currently we only support JSON, but in the future there may be other formats) we need to be able to access the real type to pass to the encoder.

To achieve this we also store a closure in a second new stored property `bodyData` at the same time (from within the generic `init` where we still have access to the real type of the body codable). This closure accepts an argument describing the format into which you want to encode the body and returns a `Data` containing the encoded form of the body.

A new struct `BodyFormat` has been added to enumerate the different supported format. Currently only JSON is supported. This was made as a struct rather than an enum to allow new formats to be added without breaking the API (enums are exhaustive and adding a case would break any switch statements relying on that.)

The `bodyData` closure performs a switch on the `BodyFormat` provided and calls the appropriate encoder on the body to convert it to `Data`. If the `BodyFormat` is not recognised, then an `UnsupportedBodyFormatError` (another new type added in this change) will be thrown. Since  `BodyFormat` only has a private initializer, no other code should be able to create them, and provided the generic initializer of `RequestError` and `BodyFormat` are kept in sync, then `UnsupportedBodyFormatError` should never be thrown.

This PR also adds a few small tests for the new initializer and properties.

Jazzy API doc has been added for the new code.


**In the `Kitura` PR** the `Router` has been updated so that codable routes will check for the existence of a `bodyData` in any `RequestError` returned by a codable route handler, and if it is non-nil then will use it to get a `Data` to send as the body of the response.

## Motivation and Context
This change allows codable route handlers to customise the body of error responses. One example of where this feature is needed is the health route generated by the Swift Server Generator and kitura-cli.

This route should send `HTTP 200 OK` when the application is healthy and `HTTP 503 Service Unavailable` when the application is not working. It should also provide a response body that is a JSON object describing the status of the application and each dependent service. This body should be sent both when the application is healthy and when it is not, and is arguably more important in the latter case as it will give information about which service is not available.

Without a custom body for `RequestError` it is not possible to send a response body if the status code is not 2xx (usually HTTP 200 OK, but it varies depending on the HTTP method, eg: `delete` uses HTTP 204 No content).

## How Has This Been Tested?
New tests have been added, tested with `swift test`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
