### PR TITLE
Issue.swift41

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,15 @@ matrix:
     - os: osx
       osx_image: xcode9.2
       sudo: required
+      env: SWIFT_SNAPSHOT=4.0.3
+    - os: linux
+      dist: trusty
+      sudo: required
+      env: SWIFT_SNAPSHOT=swift-4.1-DEVELOPMENT-SNAPSHOT-2018-02-06-a
+    - os: osx
+      osx_image: xcode9.2
+      sudo: required
+      env: SWIFT_SNAPSHOT=swift-4.1-DEVELOPMENT-SNAPSHOT-2018-02-06-a
 
 before_install:
   - git clone https://github.com/IBM-Swift/Package-Builder.git

--- a/Sources/KituraContracts/CodableQuery/Coder.swift
+++ b/Sources/KituraContracts/CodableQuery/Coder.swift
@@ -32,6 +32,10 @@ public class Coder {
 
     /// Helper method to extract the field name from a CodingKey array
     public static func getFieldName(from codingPath: [CodingKey]) -> String {
-        return codingPath.flatMap({"\($0)"}).joined(separator: ".")
+        #if swift(>=4.1)
+            return codingPath.compactMap({$0.stringValue}).joined(separator: ".")
+        #else
+            return codingPath.flatMap({$0.stringValue}).joined(separator: ".")
+        #endif
     }
 }


### PR DESCRIPTION
Resolves issues with Swift 4.1:
- Removes compilation warnings by replacing `flatMap` with `compactMap` when compiling on Swift >=4.1
- Fixes a bug where `Coder.getFieldName(codingPath:)` returns an erroneous verbose description of the CodingKeys rather than the simple String value.