### PR TITLE
feat: Add codable identifier arrays

### DIFF
--- a/Sources/KituraContracts/ClosureAliases.swift
+++ b/Sources/KituraContracts/ClosureAliases.swift
@@ -32,7 +32,7 @@ The `CodableArrayResultClosure` is used by other `Codable` aliases when respondi
 public typealias CodableArrayResultClosure<O: Codable> = ([O]?, RequestError?) -> Void
 
 /**
- The `IdentifierCodableArrayResultClosure` is used by other `Codable` aliases when responding with an array of tuples containing an identifiers and a Codable object, or an `RequestError`.
+ The `IdentifierCodableArrayResultClosure` is used by other `Codable` aliases when responding with an array of tuples containing an identifier and a Codable object, or an `RequestError`.
  */
 public typealias IdentifierCodableArrayResultClosure<Id: Identifier, O: Codable> = ([(Id, O)]?, RequestError?) -> Void
 
@@ -208,7 +208,7 @@ router.get("/users") { (respondWith: ([User]?, RequestError?) -> Void) in
 public typealias CodableArrayClosure<O: Codable> = (@escaping CodableArrayResultClosure<O>) -> Void
 
 /**
- The `IdentifierCodableArrayClosure` is for use in cases where you'd want to perform a series of actions then respond with an array of tuples containing an identifiers and a Codable object, or an `RequestError`, in the form of a `IdentifierCodableArrayResultClosure`.
+ The `IdentifierCodableArrayClosure` is for use in cases where you'd want to perform a series of actions then respond with an array of tuples containing an identifier and a Codable object, or an `RequestError`, in the form of a `IdentifierCodableArrayResultClosure`.
  
  ### Usage Example: ###
  ````

--- a/Sources/KituraContracts/ClosureAliases.swift
+++ b/Sources/KituraContracts/ClosureAliases.swift
@@ -32,6 +32,11 @@ The `CodableArrayResultClosure` is used by other `Codable` aliases when respondi
 public typealias CodableArrayResultClosure<O: Codable> = ([O]?, RequestError?) -> Void
 
 /**
+ The `IdentifierCodableArrayResultClosure` is used by other `Codable` aliases when responding with an array of tuples containing an identifiers and a Codable object, or an `RequestError`.
+ */
+public typealias IdentifierCodableArrayResultClosure<Id: Identifier, O: Codable> = ([(Id, O)]?, RequestError?) -> Void
+
+/**
 The `IdentifierCodableResultClosure` is used by other `Codable` aliases when responding with an object which conforms to Codable and/or an object that conforms to `Identifier` or `RequestError` is needed.
 */
 public typealias IdentifierCodableResultClosure<Id: Identifier, O: Codable> = (Id?, O?, RequestError?) -> Void
@@ -201,6 +206,31 @@ router.get("/users") { (respondWith: ([User]?, RequestError?) -> Void) in
 ````
 */
 public typealias CodableArrayClosure<O: Codable> = (@escaping CodableArrayResultClosure<O>) -> Void
+
+/**
+ The `IdentifierCodableArrayClosure` is for use in cases where you'd want to perform a series of actions then respond with an array of tuples containing an identifiers and a Codable object, or an `RequestError`, in the form of a `IdentifierCodableArrayResultClosure`.
+ 
+ ### Usage Example: ###
+ ````
+ router.get("/users") { (respondWith: ([(Int, User)]?, RequestError?) -> Void) in
+     if databaseConnectionIsOk {
+ 
+         ...
+ 
+         //If no errors occured and you have an array of Users you can just respond with the users by passing nil as the 'RequestError?' value.
+        respondWith([(Int, User)], nil)
+ 
+     } else {
+ 
+         ...
+ 
+         //If there has been an error you can use the respondWith call to respond with an appropiate error and passing nil for the [User]?.
+         respondWith(nil, .internalServerError)
+     }
+ }
+ ````
+ */
+public typealias IdentifierCodableArrayClosure<Id: Identifier, O: Codable> = (@escaping IdentifierCodableArrayResultClosure<Id, O>) -> Void
 
 /**
 The `SimpleCodableClosure` is for use in cases where you'd want to perform a series of actions then respond with an object conforming to `Codable` or a `RequestError` in the form of a `CodableResultClosure`.

--- a/Sources/KituraContracts/Contracts.swift
+++ b/Sources/KituraContracts/Contracts.swift
@@ -471,7 +471,7 @@ public enum IdentifierError: Error {
 /**
  An identifier for an entity with a string representation.
  */
-public protocol Identifier {
+public protocol Identifier: Hashable {
     /// Creates an identifier from a given string value.
     /// - Throws: An IdentifierError.invalidValue if the given string is not a valid representation.
     init(value: String) throws

--- a/Sources/KituraContracts/Contracts.swift
+++ b/Sources/KituraContracts/Contracts.swift
@@ -471,7 +471,7 @@ public enum IdentifierError: Error {
 /**
  An identifier for an entity with a string representation.
  */
-public protocol Identifier: Hashable {
+public protocol Identifier {
     /// Creates an identifier from a given string value.
     /// - Throws: An IdentifierError.invalidValue if the given string is not a valid representation.
     init(value: String) throws


### PR DESCRIPTION
Added type Aliases and docs for returning an array of tuples of identifiers to codable object. 

This is needed for the corresponding [pull request](https://github.com/IBM-Swift/Kitura/pulls) in Kitura

Has been tested with swift test and everything passed.