### PR TITLE
decode empty string as nil

### DIFF
--- a/Sources/KituraContracts/CodableQuery/QueryDecoder.swift
+++ b/Sources/KituraContracts/CodableQuery/QueryDecoder.swift
@@ -56,7 +56,8 @@ public class QueryDecoder: Coder, Decoder {
      Initializer with a `[String : String]` dictionary.
      */
     public init(dictionary: [String : String]) {
-        self.dictionary = dictionary
+        let removedEmptydictionary = dictionary.filter { !$0.value.isEmpty }
+        self.dictionary = removedEmptydictionary
         super.init()
     }
 

--- a/Tests/KituraContractsTests/QueryCoderTests.swift
+++ b/Tests/KituraContractsTests/QueryCoderTests.swift
@@ -93,6 +93,7 @@ class QueryCoderTests: XCTestCase {
         public let intField: Int
         public let optionalIntField: Int?
         public let stringField: String
+        public let optionalStringField: String?
         public let intArray: [Int]
         public let dateField: Date
         public let optionalDateField: Date?
@@ -103,6 +104,7 @@ class QueryCoderTests: XCTestCase {
                     lhs.intField == rhs.intField &&
                     lhs.optionalIntField == rhs.optionalIntField &&
                     lhs.stringField == rhs.stringField &&
+                    lhs.optionalStringField == rhs.optionalStringField &&
                     lhs.intArray == rhs.intArray &&
                     lhs.dateField == rhs.dateField &&
                     lhs.optionalDateField == rhs.optionalDateField &&
@@ -119,9 +121,9 @@ class QueryCoderTests: XCTestCase {
         }
     }
 
-    let expectedDict = ["boolField": "true", "intField": "23", "stringField": "a string", "intArray": "1,2,3", "dateField": "2017-10-31T16:15:56+0000", "optionalDateField": "2017-10-31T16:15:56+0000", "nested": "{\"nestedIntField\":333,\"nestedStringField\":\"nested string\"}" ]
+    let expectedDict = ["boolField": "true", "intField": "23", "stringField": "a string", "optionalStringField": "", "intArray": "1,2,3", "dateField": "2017-10-31T16:15:56+0000", "optionalDateField": "", "nested": "{\"nestedIntField\":333,\"nestedStringField\":\"nested string\"}" ]
 
-    let expectedQueryString = "?boolField=true&intArray=1%2C2%2C3&stringField=a%20string&intField=23&dateField=2017-12-07T21:42:06%2B0000&nested=%7B\"nestedStringField\":\"nested%20string\"%2C\"nestedIntField\":333%7D"
+    let expectedQueryString = "?boolField=true&intArray=1%2C2%2C3&stringField=a%20string&optionalStringField=&intField=23&dateField=2017-12-07T21:42:06%2B0000&nested=%7B\"nestedStringField\":\"nested%20string\"%2C\"nestedIntField\":333%7D"
 
     let expectedDateStr = "2017-10-31T16:15:56+0000"
     let expectedDate = Coder().dateFormatter.date(from: "2017-10-31T16:15:56+0000")!
@@ -130,9 +132,10 @@ class QueryCoderTests: XCTestCase {
                                   intField: 23,
                                   optionalIntField: nil,
                                   stringField: "a string",
+                                  optionalStringField: nil,
                                   intArray: [1, 2, 3],
                                   dateField: Coder().dateFormatter.date(from: "2017-10-31T16:15:56+0000")!,
-                                  optionalDateField: Coder().dateFormatter.date(from: "2017-10-31T16:15:56+0000")!,
+                                  optionalDateField: nil,
                                   nested: Nested(nestedIntField: 333, nestedStringField: "nested string"))
 
     func testQueryDecoder() {
@@ -147,7 +150,7 @@ class QueryCoderTests: XCTestCase {
 
     func testQueryEncoder() {
 
-        let query = MyQuery(boolField: true, intField: -1, optionalIntField: 282, stringField: "a string", intArray: [1, -1, 3], dateField: expectedDate, optionalDateField: expectedDate, nested: Nested(nestedIntField: 333, nestedStringField: "nested string"))
+        let query = MyQuery(boolField: true, intField: -1, optionalIntField: 282, stringField: "a string", optionalStringField: "", intArray: [1, -1, 3], dateField: expectedDate, optionalDateField: expectedDate, nested: Nested(nestedIntField: 333, nestedStringField: "nested string"))
 
         let myInts = SimpleStruct(intField: 1)
 


### PR DESCRIPTION
## Description
This pull requests changes the query decoder dictionary initializer to treat the empty string as nil. 

## Motivation and Context
In response to [issue #1261](https://github.com/IBM-Swift/Kitura/issues/1261). When using HTML forms to send data, An empty form will send an empty string to signify nil for all data types (e.g. numbers, dates). 

When decoding a form with optional inputs for these data types the user would get unprocessableEntity since the empty string cannot be converted to a Bool/ date etc. 

This change will also mean that a form submitting an empty string will treat it as being nil instead of the empty string and it will be rejected if the field is non optional.

This change was originally implemented on a [PR to Kitura](https://github.com/IBM-Swift/Kitura/pull/1262) however it seems to make more sense to implement it inside the decoder.

## How Has This Been Tested?
Tests were added and run Kitura in a [previous PR](https://github.com/IBM-Swift/Kitura/pull/1262) to check for a number submitted as an empty string being accepted for a struct with an optional value. Test have also been added to show an empty string being rejected for a non optional String and number. They now pass with this change in Kitura contracts

This change will conflict with @NocturnalSolutions [PR](https://github.com/IBM-Swift/KituraContracts/pull/16) but it shouldn't be difficult to resolve.