### PR TITLE
fix: Add custom decoder for TypeDecoder

### DIFF
--- a/Sources/KituraContracts/Contracts.swift
+++ b/Sources/KituraContracts/Contracts.swift
@@ -1158,7 +1158,7 @@ public protocol Operation: Codable {
 */
 public struct GreaterThan<I: Identifier>: Operation {
   private var value: I
-  private var `operator`: Operator = .greaterThan
+  private let `operator`: Operator = .greaterThan
 
   /// Creates a GreaterThan instance from a given Identifier value
   public init(value: I) {
@@ -1184,12 +1184,6 @@ public struct GreaterThan<I: Identifier>: Operation {
   public func getOperator() -> Operator {
     return self.`operator`
   }
-
-  // Custom decoder (Fix for TypeDecoder because it cannot return dummy enum Operator value)
-  public init(from decoder: Decoder) throws {
-    let values = try decoder.container(keyedBy: CodingKeys.self)
-    value = try values.decode(I.self, forKey: .value)
-  }
 }
 
 /**
@@ -1211,7 +1205,7 @@ public struct GreaterThan<I: Identifier>: Operation {
 */
 public struct GreaterThanOrEqual<I: Identifier>: Operation {
   private var value: I
-  private var `operator`: Operator = .greaterThanOrEqual
+  private let `operator`: Operator = .greaterThanOrEqual
 
   /// Creates a GreaterThanOrEqual instance from a given Identifier value
   public init(value: I) {
@@ -1237,12 +1231,6 @@ public struct GreaterThanOrEqual<I: Identifier>: Operation {
   public func getOperator() -> Operator {
     return self.`operator`
   }
-
-  // Custom decoder (Fix for TypeDecoder because it cannot return dummy enum Operator value)
-  public init(from decoder: Decoder) throws {
-    let values = try decoder.container(keyedBy: CodingKeys.self)
-    value = try values.decode(I.self, forKey: .value)
-  }
 }
 
 /**
@@ -1265,7 +1253,7 @@ public struct GreaterThanOrEqual<I: Identifier>: Operation {
 */
 public struct LowerThan<I: Identifier>: Operation {
   private var value: I
-  private var `operator`: Operator = .lowerThan
+  private let `operator`: Operator = .lowerThan
 
   /// Creates a LowerThan instance from a given Identifier value
   public init(value: I) {
@@ -1290,12 +1278,6 @@ public struct LowerThan<I: Identifier>: Operation {
   /// Returns the Operator
   public func getOperator() -> Operator {
     return self.`operator`
-  }
-
-  // Custom decoder (Fix for TypeDecoder because it cannot return dummy enum Operator value)
-  public init(from decoder: Decoder) throws {
-    let values = try decoder.container(keyedBy: CodingKeys.self)
-    value = try values.decode(I.self, forKey: .value)
   }
 }
 
@@ -1318,7 +1300,7 @@ public struct LowerThan<I: Identifier>: Operation {
 */
 public struct LowerThanOrEqual<I: Identifier>: Operation {
   private var value: I
-  private var `operator`: Operator = .lowerThanOrEqual
+  private let `operator`: Operator = .lowerThanOrEqual
 
   /// Creates a LowerThan instance from a given Identifier value
   public init(value: I) {
@@ -1343,12 +1325,6 @@ public struct LowerThanOrEqual<I: Identifier>: Operation {
   /// Returns the Operator
   public func getOperator() -> Operator {
     return self.`operator`
-  }
-
-  // Custom decoder (Fix for TypeDecoder because it cannot return dummy enum Operator value)
-  public init(from decoder: Decoder) throws {
-    let values = try decoder.container(keyedBy: CodingKeys.self)
-    value = try values.decode(I.self, forKey: .value)
   }
 }
 
@@ -1372,7 +1348,7 @@ public struct LowerThanOrEqual<I: Identifier>: Operation {
 public struct InclusiveRange<I: Identifier>: Operation {
   private var start: I
   private var end: I
-  private var `operator`: Operator = .inclusiveRange
+  private let `operator`: Operator = .inclusiveRange
 
   /// Creates a InclusiveRange instance from given start and end values
   public init(start: I, end: I) {
@@ -1404,13 +1380,6 @@ public struct InclusiveRange<I: Identifier>: Operation {
   public func getOperator() -> Operator {
     return self.`operator`
   }
-
-  // Custom decoder (Fix for TypeDecoder because it cannot return dummy enum Operator value)
-  public init(from decoder: Decoder) throws {
-    let values = try decoder.container(keyedBy: CodingKeys.self)
-    start = try values.decode(I.self, forKey: .start)
-    end = try values.decode(I.self, forKey: .end)
-  }
 }
 
 /**
@@ -1433,7 +1402,7 @@ public struct InclusiveRange<I: Identifier>: Operation {
 public struct ExclusiveRange<I: Identifier>: Operation {
   private var start: I
   private var end: I
-  private var `operator`: Operator = .exclusiveRange
+  private let `operator`: Operator = .exclusiveRange
 
   /// Creates a ExclusiveRange instance from given start and end values
   public init(start: I, end: I) {
@@ -1464,13 +1433,6 @@ public struct ExclusiveRange<I: Identifier>: Operation {
   /// Returns the Operator
   public func getOperator() -> Operator {
     return self.`operator`
-  }
-
-  // Custom decoder (Fix for TypeDecoder because it cannot return dummy enum Operator value)
-  public init(from decoder: Decoder) throws {
-    let values = try decoder.container(keyedBy: CodingKeys.self)
-    start = try values.decode(I.self, forKey: .start)
-    end = try values.decode(I.self, forKey: .end)
   }
 }
 

--- a/Sources/KituraContracts/Contracts.swift
+++ b/Sources/KituraContracts/Contracts.swift
@@ -1184,6 +1184,12 @@ public struct GreaterThan<I: Identifier>: Operation {
   public func getOperator() -> Operator {
     return self.`operator`
   }
+
+  // Custom decoder (Fix for TypeDecoder because it cannot return dummy enum Operator value)
+  public init(from decoder: Decoder) throws {
+    let values = try decoder.container(keyedBy: CodingKeys.self)
+    value = try values.decode(I.self, forKey: .value)
+  }
 }
 
 /**
@@ -1230,6 +1236,12 @@ public struct GreaterThanOrEqual<I: Identifier>: Operation {
   /// Returns the Operator
   public func getOperator() -> Operator {
     return self.`operator`
+  }
+
+  // Custom decoder (Fix for TypeDecoder because it cannot return dummy enum Operator value)
+  public init(from decoder: Decoder) throws {
+    let values = try decoder.container(keyedBy: CodingKeys.self)
+    value = try values.decode(I.self, forKey: .value)
   }
 }
 
@@ -1279,6 +1291,12 @@ public struct LowerThan<I: Identifier>: Operation {
   public func getOperator() -> Operator {
     return self.`operator`
   }
+
+  // Custom decoder (Fix for TypeDecoder because it cannot return dummy enum Operator value)
+  public init(from decoder: Decoder) throws {
+    let values = try decoder.container(keyedBy: CodingKeys.self)
+    value = try values.decode(I.self, forKey: .value)
+  }
 }
 
 /**
@@ -1325,6 +1343,12 @@ public struct LowerThanOrEqual<I: Identifier>: Operation {
   /// Returns the Operator
   public func getOperator() -> Operator {
     return self.`operator`
+  }
+
+  // Custom decoder (Fix for TypeDecoder because it cannot return dummy enum Operator value)
+  public init(from decoder: Decoder) throws {
+    let values = try decoder.container(keyedBy: CodingKeys.self)
+    value = try values.decode(I.self, forKey: .value)
   }
 }
 
@@ -1380,6 +1404,13 @@ public struct InclusiveRange<I: Identifier>: Operation {
   public func getOperator() -> Operator {
     return self.`operator`
   }
+
+  // Custom decoder (Fix for TypeDecoder because it cannot return dummy enum Operator value)
+  public init(from decoder: Decoder) throws {
+    let values = try decoder.container(keyedBy: CodingKeys.self)
+    start = try values.decode(I.self, forKey: .start)
+    end = try values.decode(I.self, forKey: .end)
+  }
 }
 
 /**
@@ -1433,6 +1464,13 @@ public struct ExclusiveRange<I: Identifier>: Operation {
   /// Returns the Operator
   public func getOperator() -> Operator {
     return self.`operator`
+  }
+
+  // Custom decoder (Fix for TypeDecoder because it cannot return dummy enum Operator value)
+  public init(from decoder: Decoder) throws {
+    let values = try decoder.container(keyedBy: CodingKeys.self)
+    start = try values.decode(I.self, forKey: .start)
+    end = try values.decode(I.self, forKey: .end)
   }
 }
 


### PR DESCRIPTION
When generating swagger with Query Parameters, Neil realised that the TypeDecoder could not decode some special types like `GreaterThan`. This is due to the fact that these types contain a Operator Enum field.

When decoding, the decoder has to return a value in a specific type. In this example, the value returned is a `String`:
```
value = container.decode(Sting.self, key: .key)
```

In the case of the TypeDecoder, it returns dummy values to keep the compiler happy. When decoding an Enum is returns a dummy value. This causes an error because that dummy value is not of the same type as that Enum. Furthermore,  we could not construct an enum from `rawValue` because none of the cases match the empty string.

To solve this issue, we implement a custom decoder for these special types where we decide to not decode the `Operator` Enum field since it already has a default value. We will only decode the value field associated with those types.
