### PR TITLE
Feat: Add BodyEncoder and BodyDecoder

### DIFF
--- a/Sources/KituraContracts/BodyDecoder.swift
+++ b/Sources/KituraContracts/BodyDecoder.swift
@@ -1,0 +1,28 @@
+/**
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Foundation
+
+public protocol BodyDecoder {
+    func decode<T>(_ type: T.Type, from data: Data) throws -> T where T : Decodable
+    var contentType: String { get }
+}
+
+extension JSONDecoder: BodyDecoder {
+    public var contentType: String {
+        return "json"
+    }
+}

--- a/Sources/KituraContracts/BodyDecoder.swift
+++ b/Sources/KituraContracts/BodyDecoder.swift
@@ -20,7 +20,7 @@ import Foundation
  A class that conforms to `BodyDecoder` must be able to decode from `Data` into a `Codable` type.
  This class can then be used to produce input objects for a Codable route.
  */
-public protocol BodyDecoder {
+public protocol BodyDecoder: AnyObject {
     func decode<T : Decodable>(_ type: T.Type, from data: Data) throws -> T
 }
 

--- a/Sources/KituraContracts/BodyDecoder.swift
+++ b/Sources/KituraContracts/BodyDecoder.swift
@@ -16,18 +16,12 @@
 
 import Foundation
 
+/**
+ A class that conforms to `BodyDecoder` must be able to decode from `Data` into a `Codable` type.
+ This class can then be used to produce input objects for a Codable route.
+ */
 public protocol BodyDecoder {
-    func decode<T>(_ type: T.Type, from data: Data) throws -> T where T : Decodable
-    var contentType: String { get }
+    func decode<T : Decodable>(_ type: T.Type, from data: Data) throws -> T
 }
 
-extension JSONDecoder: BodyDecoder {
-    public var contentType: String {
-        return "json"
-    }
-}
-extension QueryDecoder: BodyDecoder {
-    public var contentType: String {
-        return "application/x-www-form-urlencoded"
-    }
-}
+extension JSONDecoder: BodyDecoder {}

--- a/Sources/KituraContracts/BodyDecoder.swift
+++ b/Sources/KituraContracts/BodyDecoder.swift
@@ -26,3 +26,8 @@ extension JSONDecoder: BodyDecoder {
         return "json"
     }
 }
+extension QueryDecoder: BodyDecoder {
+    public var contentType: String {
+        return "application/x-www-form-urlencoded"
+    }
+}

--- a/Sources/KituraContracts/BodyEncoder.swift
+++ b/Sources/KituraContracts/BodyEncoder.swift
@@ -16,17 +16,12 @@
 
 import Foundation
 
+/**
+ A class that conforms to `BodyEncoder` must be able to encode a `Codable` type into `Data`.
+ This class can then be used to produce output objects for a Codable route.
+ */
 public protocol BodyEncoder {
     func encode<T : Encodable>(_ value: T) throws -> Data
-    var contentType: String { get }
 }
-extension JSONEncoder: BodyEncoder {
-    public var contentType: String {
-        return "json"
-    }
-}
-extension QueryEncoder: BodyEncoder {
-    public var contentType: String {
-        return "application/x-www-form-urlencoded"
-    }
-}
+extension JSONEncoder: BodyEncoder {}
+

--- a/Sources/KituraContracts/BodyEncoder.swift
+++ b/Sources/KituraContracts/BodyEncoder.swift
@@ -20,7 +20,7 @@ import Foundation
  A class that conforms to `BodyEncoder` must be able to encode a `Codable` type into `Data`.
  This class can then be used to produce output objects for a Codable route.
  */
-public protocol BodyEncoder {
+public protocol BodyEncoder: AnyObject {
     func encode<T : Encodable>(_ value: T) throws -> Data
 }
 extension JSONEncoder: BodyEncoder {}

--- a/Sources/KituraContracts/BodyEncoder.swift
+++ b/Sources/KituraContracts/BodyEncoder.swift
@@ -20,9 +20,13 @@ public protocol BodyEncoder {
     func encode<T : Encodable>(_ value: T) throws -> Data
     var contentType: String { get }
 }
-
 extension JSONEncoder: BodyEncoder {
     public var contentType: String {
         return "json"
+    }
+}
+extension QueryEncoder: BodyEncoder {
+    public var contentType: String {
+        return "application/x-www-form-urlencoded"
     }
 }

--- a/Sources/KituraContracts/BodyEncoder.swift
+++ b/Sources/KituraContracts/BodyEncoder.swift
@@ -1,0 +1,28 @@
+/**
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Foundation
+
+public protocol BodyEncoder {
+    func encode<T : Encodable>(_ value: T) throws -> Data
+    var contentType: String { get }
+}
+
+extension JSONEncoder: BodyEncoder {
+    public var contentType: String {
+        return "json"
+    }
+}

--- a/Sources/KituraContracts/CodableQuery/QueryDecoder.swift
+++ b/Sources/KituraContracts/CodableQuery/QueryDecoder.swift
@@ -38,7 +38,7 @@ import LoggerAPI
  - Non-optional `Bool` decodes to `false`
  - All other non-optional types throw a decoding error
  */
-public class QueryDecoder: Coder, Decoder {
+public class QueryDecoder: Coder, Decoder, BodyDecoder {
     
     /**
      The coding key path.

--- a/Sources/KituraContracts/CodableQuery/QueryEncoder.swift
+++ b/Sources/KituraContracts/CodableQuery/QueryEncoder.swift
@@ -37,7 +37,7 @@ extension CharacterSet {
  }
  ````
  */
-public class QueryEncoder: Coder, Encoder {
+public class QueryEncoder: Coder, Encoder, BodyEncoder {
 
     /**
      A `[String: String]` dictionary.


### PR DESCRIPTION
This pull requests adds two protocols BodyEncoder and BodyDecoder and extends Query and JSON encoders/decoders to conform to them. These will be used in Kitura for [custom enoders/decoders](https://github.com/IBM-Swift/Kitura/pull/1309). 

This depends on pr [28](https://github.com/IBM-Swift/KituraContracts/pull/28) which adds an encode to and decode from data to Query encoder and decoder.