### PR TITLE
Build against Swift 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,11 @@ matrix:
       dist: trusty
       sudo: required
       services: docker
+      env: DOCKER_IMAGE=ubuntu:16.04 SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
+    - os: linux
+      dist: trusty
+      sudo: required
+      services: docker
       env: DOCKER_IMAGE=ubuntu:18.04
     - os: osx
       osx_image: xcode9.2
@@ -43,6 +48,10 @@ matrix:
     - os: osx
       osx_image: xcode10
       sudo: required
+    - os: osx
+      osx_image: xcode10.1
+      sudo: required
+      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
 
 before_install:
   - git clone https://github.com/IBM-Swift/Package-Builder.git

--- a/Sources/KituraContracts/Contracts.swift
+++ b/Sources/KituraContracts/Contracts.swift
@@ -295,7 +295,7 @@ public struct RequestError: RawRepresentable, Equatable, Hashable, Comparable, E
 /**
  Extends `RequestError` to provide HTTP specific error code and reason values.
  */
-public extension RequestError {
+extension RequestError {
 
     /**
     The HTTP status code for the error.


### PR DESCRIPTION
Adds testing with a Swift 5 development snapshot. The snapshot is defined in Travis as `SWIFT_DEVELOPMENT_SNAPSHOT` consistently across the IBM-Swift repos, to enable us to automate updating the version.

Compilation warnings relating to redundant access modifiers in an extension have been resolved, by removing the default access modifier on the extension.