### PR TITLE
Add subfolder to pod source files

### DIFF
--- a/KituraContracts.podspec
+++ b/KituraContracts.podspec
@@ -9,6 +9,6 @@ Pod::Spec.new do |s|
   s.module_name  = 'KituraContracts'
   s.ios.deployment_target = "10.0"
   s.source   = { :git => "https://github.com/IBM-Swift/KituraContracts.git", :tag => s.version }
-  s.source_files = "Sources/KituraContracts/*.swift", "Sources/KituraContracts/CodableQuery/*.swift"
+  s.source_files = "Sources/**/*.swift"
   s.dependency 'LoggerAPI', '~> 1.7'
 end

--- a/KituraContracts.podspec
+++ b/KituraContracts.podspec
@@ -9,6 +9,6 @@ Pod::Spec.new do |s|
   s.module_name  = 'KituraContracts'
   s.ios.deployment_target = "10.0"
   s.source   = { :git => "https://github.com/IBM-Swift/KituraContracts.git", :tag => s.version }
-  s.source_files = "Sources/KituraContracts/*.swift"
+  s.source_files = "Sources/KituraContracts/*.swift", "Sources/KituraContracts/CodableQuery/*.swift"
   s.dependency 'LoggerAPI', '~> 1.7'
 end


### PR DESCRIPTION
The podspec file was missing the subfolders from its sources. This PR adds them so that they will be picked up by cocoapods. 
The published pod has already been updated with this fix but we would like the podspec file in master to reflect the current published pod.