### PR TITLE
Add osx, watchOS and tvOS to podfile

### DIFF
--- a/KituraContracts.podspec
+++ b/KituraContracts.podspec
@@ -7,7 +7,10 @@ Pod::Spec.new do |s|
   s.license     = { :type => "Apache License, Version 2.0" }
   s.author     = "IBM"
   s.module_name  = 'KituraContracts'
+  s.osx.deployment_target = "10.11"
   s.ios.deployment_target = "10.0"
+  s.tvos.deployment_target = "9.1"
+  s.watchos.deployment_target = "2.0"
   s.source   = { :git => "https://github.com/IBM-Swift/KituraContracts.git", :tag => s.version }
   s.source_files = "Sources/**/*.swift"
   s.dependency 'LoggerAPI', '~> 1.7'


### PR DESCRIPTION
This pull request adds tvOS, osx and watchOS to the podspec file so that the pod can be used on those devices.
Since we don't use any platform features this can be added without any code changes.

This is dependent on [this PR](https://github.com/IBM-Swift/LoggerAPI/pull/42) to update LoggerAPI