### PR TITLE
Added QueryEncoder and QueryDecoder support for alternate date formats

### DIFF
--- a/Sources/KituraContracts/CodableQuery/Extensions.swift
+++ b/Sources/KituraContracts/CodableQuery/Extensions.swift
@@ -181,7 +181,7 @@ extension String {
     - Parameter formatter: The designated DateFormatter to convert the string with.
     - Returns: The Date? object. Some on success / nil on failure.
     */
-    public func dateFormatted(_ formatter: DateFormatter) -> Date? {
+    public func date(_ formatter: DateFormatter) -> Date? {
         return formatter.date(from: self)
     }
 
@@ -191,7 +191,7 @@ extension String {
     - Parameter formatter: The designated DateFormatter to convert the string with.
     - Returns: The [Date]? object. Some on success / nil on failure.
     */
-    public func dateArrayFormatted(_ formatter: DateFormatter) -> [Date]? {
+    public func dateArray(_ formatter: DateFormatter) -> [Date]? {
 
         let strs: [String] = self.components(separatedBy: ",")
         let dates = strs.map { formatter.date(from: $0) }.filter { $0 != nil }.map { $0! }

--- a/Sources/KituraContracts/CodableQuery/Extensions.swift
+++ b/Sources/KituraContracts/CodableQuery/Extensions.swift
@@ -191,13 +191,63 @@ extension String {
     - Parameter formatter: The designated DateFormatter to convert the string with.
     - Returns: The [Date]? object. Some on success / nil on failure.
     */
-    public func dateArray(_ formatter: DateFormatter) -> [Date]? {
+    public func dateArrayFormatted(_ formatter: DateFormatter) -> [Date]? {
+
         let strs: [String] = self.components(separatedBy: ",")
         let dates = strs.map { formatter.date(from: $0) }.filter { $0 != nil }.map { $0! }
         if dates.count == strs.count {
             return dates
         }
         return nil
+    }
+
+    public func dateArray1970() -> [Date]? {
+
+        let strs: [String] = self.components(separatedBy: ",")
+        let dbs = strs.compactMap(Double.init)
+        let dates = dbs.map { Date(timeIntervalSince1970: $0) }.filter { $0 != nil }.map { $0! }
+        if dates.count == dbs.count {
+            return dates
+        }
+        return nil
+
+    }
+
+    public func dateArray1970M() -> [Date]? {
+
+        let strs: [String] = self.components(separatedBy: ",")
+        let dbs = strs.compactMap(Double.init)
+        let dates = dbs.map { Date(timeIntervalSince1970: ($0)/1000) }.filter { $0 != nil }.map { $0! }
+        if dates.count == dbs.count {
+            return dates
+        }
+        return nil
+    }
+
+    public func dateArrayISO() -> [Date]? {
+
+        if #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
+            let strs: [String] = self.components(separatedBy: ",")
+            let dates = strs.map { _iso8601Formatter.date(from: $0) }
+            if dates.count == strs.count {
+                return dates as? [Date]
+            }
+            return nil
+        } else {
+            fatalError("ISO8601DateFormatter is unavailable on this platform.")
+        }
+    }
+
+    public func dateArrayDeferred() -> [Date]? {
+
+        let strs: [String] = self.components(separatedBy: ",")
+        let dbs = strs.compactMap(Double.init)
+        let dates = dbs.map { Date(timeIntervalSinceReferenceDate: $0) }.filter { $0 != nil }.map { $0! }
+        if dates.count == dbs.count {
+            return dates
+        }
+        return nil
+
     }
 
     /// Helper Method to decode a string to an LosslessStringConvertible array types.

--- a/Sources/KituraContracts/CodableQuery/Extensions.swift
+++ b/Sources/KituraContracts/CodableQuery/Extensions.swift
@@ -181,7 +181,7 @@ extension String {
     - Parameter formatter: The designated DateFormatter to convert the string with.
     - Returns: The Date? object. Some on success / nil on failure.
     */
-    public func date(_ formatter: DateFormatter) -> Date? {
+    public func dateFormatted(_ formatter: DateFormatter) -> Date? {
         return formatter.date(from: self)
     }
 
@@ -235,8 +235,8 @@ extension String {
         }
         let key = String(self[..<range.lowerBound])
         let value = String(self[range.upperBound...])
-        
-        let valueReplacingPlus = value.replacingOccurrences(of: "+", with: " ")
+
+        let valueReplacingPlus = value.replacingOccurrences(of: "+", with: "+")
         let decodedValue = valueReplacingPlus.removingPercentEncoding
         if decodedValue == nil {
             Log.warning("Unable to decode query parameter \(key) (coded value: \(valueReplacingPlus)")

--- a/Sources/KituraContracts/CodableQuery/Extensions.swift
+++ b/Sources/KituraContracts/CodableQuery/Extensions.swift
@@ -205,7 +205,7 @@ extension String {
 
         let strs: [String] = self.components(separatedBy: ",")
         let dbs = strs.compactMap(Double.init)
-        let dates = dbs.map { Date(timeIntervalSince1970: $0) }.filter { $0 != nil }.map { $0! }
+        let dates = dbs.map { Date(timeIntervalSince1970: $0) }
         if dates.count == dbs.count {
             return dates
         }
@@ -217,7 +217,7 @@ extension String {
 
         let strs: [String] = self.components(separatedBy: ",")
         let dbs = strs.compactMap(Double.init)
-        let dates = dbs.map { Date(timeIntervalSince1970: ($0)/1000) }.filter { $0 != nil }.map { $0! }
+        let dates = dbs.map { Date(timeIntervalSince1970: ($0)/1000) }
         if dates.count == dbs.count {
             return dates
         }
@@ -242,12 +242,11 @@ extension String {
 
         let strs: [String] = self.components(separatedBy: ",")
         let dbs = strs.compactMap(Double.init)
-        let dates = dbs.map { Date(timeIntervalSinceReferenceDate: $0) }.filter { $0 != nil }.map { $0! }
+        let dates = dbs.map { Date(timeIntervalSinceReferenceDate: $0) }
         if dates.count == dbs.count {
             return dates
         }
         return nil
-
     }
 
     /// Helper Method to decode a string to an LosslessStringConvertible array types.

--- a/Sources/KituraContracts/CodableQuery/Extensions.swift
+++ b/Sources/KituraContracts/CodableQuery/Extensions.swift
@@ -209,7 +209,11 @@ extension String {
     public func dateArray1970() -> [Date]? {
 
         let strs: [String] = self.components(separatedBy: ",")
-        let dbs = strs.compactMap(Double.init)
+        #if swift(>=4.1)
+            let dbs = strs.compactMap(Double.init)
+        #else
+            let dbs = strs.flatMap(Double.init)
+        #endif
         let dates = dbs.map { Date(timeIntervalSince1970: $0) }
         if dates.count == dbs.count {
             return dates
@@ -226,7 +230,11 @@ extension String {
     public func dateArray1970M() -> [Date]? {
 
         let strs: [String] = self.components(separatedBy: ",")
-        let dbs = strs.compactMap(Double.init)
+        #if swift(>=4.1)
+            let dbs = strs.compactMap(Double.init)
+        #else
+            let dbs = strs.flatMap(Double.init)
+        #endif
         let dates = dbs.map { Date(timeIntervalSince1970: ($0)/1000) }
         if dates.count == dbs.count {
             return dates
@@ -261,7 +269,11 @@ extension String {
     public func dateArrayDeferred() -> [Date]? {
 
         let strs: [String] = self.components(separatedBy: ",")
-        let dbs = strs.compactMap(Double.init)
+        #if swift(>=4.1)
+            let dbs = strs.compactMap(Double.init)
+        #else
+            let dbs = strs.flatMap(Double.init)
+        #endif
         let dates = dbs.map { Date(timeIntervalSinceReferenceDate: $0) }
         if dates.count == dbs.count {
             return dates

--- a/Sources/KituraContracts/CodableQuery/Extensions.swift
+++ b/Sources/KituraContracts/CodableQuery/Extensions.swift
@@ -186,7 +186,7 @@ extension String {
     }
 
     /**
-    Converts the given String to a [Date]?.
+    Converts the given String to a [Date]? object using the DateFormatter supplied.
     
     - Parameter formatter: The designated DateFormatter to convert the string with.
     - Returns: The [Date]? object. Some on success / nil on failure.
@@ -201,6 +201,11 @@ extension String {
         return nil
     }
 
+    /**
+    Converts the given String to a [Date]? object using timeIntervalSince1970 in seconds.
+
+    - Returns: The [Date]? object. Some on success / nil on failure.
+    */
     public func dateArray1970() -> [Date]? {
 
         let strs: [String] = self.components(separatedBy: ",")
@@ -213,6 +218,11 @@ extension String {
 
     }
 
+    /**
+    Converts the given String to a [Date]? object using timeIntervalSince1970 in milliseconds.
+
+    - Returns: The [Date]? object. Some on success / nil on failure.
+    */
     public func dateArray1970M() -> [Date]? {
 
         let strs: [String] = self.components(separatedBy: ",")
@@ -224,6 +234,11 @@ extension String {
         return nil
     }
 
+    /**
+    Converts the given String to a [Date]? object using an ISO8601 formatting.
+
+    - Returns: The [Date]? object. Some on success / nil on failure.
+    */
     public func dateArrayISO() -> [Date]? {
 
         if #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
@@ -238,6 +253,11 @@ extension String {
         }
     }
 
+    /**
+    Converts the given String to a [Date]? object using deferredToDate formatting.
+
+    - Returns: The [Date]? object. Some on success / nil on failure.
+    */
     public func dateArrayDeferred() -> [Date]? {
 
         let strs: [String] = self.components(separatedBy: ",")
@@ -285,7 +305,7 @@ extension String {
         let key = String(self[..<range.lowerBound])
         let value = String(self[range.upperBound...])
 
-        let valueReplacingPlus = value.replacingOccurrences(of: "+", with: "+")
+        let valueReplacingPlus = value.replacingOccurrences(of: "+", with: " ")
         let decodedValue = valueReplacingPlus.removingPercentEncoding
         if decodedValue == nil {
             Log.warning("Unable to decode query parameter \(key) (coded value: \(valueReplacingPlus)")
@@ -293,3 +313,11 @@ extension String {
         return (key: key, value: decodedValue ?? valueReplacingPlus)
     }
 }
+
+/// ISO8601 Formatter used for formatting ISO8601 dates.
+@available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+public var _iso8601Formatter: ISO8601DateFormatter = {
+let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = .withInternetDateTime
+return formatter
+}()

--- a/Sources/KituraContracts/CodableQuery/Extensions.swift
+++ b/Sources/KituraContracts/CodableQuery/Extensions.swift
@@ -331,7 +331,7 @@ extension String {
     }
 }
 
-/// ISO8601 Formatter used for formatting ISO8601 dates.
+// ISO8601 Formatter used for formatting ISO8601 dates.
 @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
 var _iso8601Formatter: ISO8601DateFormatter = {
 let formatter = ISO8601DateFormatter()

--- a/Sources/KituraContracts/CodableQuery/QueryDecoder.swift
+++ b/Sources/KituraContracts/CodableQuery/QueryDecoder.swift
@@ -188,6 +188,8 @@ public class QueryDecoder: Coder, Decoder, BodyDecoder {
             case .deferredToDate:
                 return try decodeType(Date(timeIntervalSinceReferenceDate: (fieldValue?.double)!), to: T.self)
             case .secondsSince1970:
+                print(self)
+
                 return try decodeType(Date(timeIntervalSince1970: (fieldValue?.double)!), to: T.self)
             case .millisecondsSince1970:
                 return try decodeType(Date(timeIntervalSince1970: ((fieldValue?.double)!)/1000), to: T.self)
@@ -205,6 +207,7 @@ public class QueryDecoder: Coder, Decoder, BodyDecoder {
             case .formatted(let formatted):
                 return try decodeType(fieldValue?.dateFormatted(formatted), to: T.self)
             case .custom(let closure):
+                
                 return try decodeType(closure(self), to: T.self)
             @unknown default:
                 fatalError()
@@ -221,8 +224,8 @@ public class QueryDecoder: Coder, Decoder, BodyDecoder {
                 return try decodeType(fieldValue?.dateArrayISO(), to: T.self)
             case .formatted(let formatter):
                 return try decodeType(fieldValue?.dateArrayFormatted(formatter), to: T.self)
-            case .custom(_):
-                return print ("Test") as! T
+            case .custom(let closure):
+                return try decodeType(closure(self), to: T.self)
             @unknown default:
                 fatalError()
             }

--- a/Sources/KituraContracts/CodableQuery/QueryDecoder.swift
+++ b/Sources/KituraContracts/CodableQuery/QueryDecoder.swift
@@ -211,6 +211,9 @@ public class QueryDecoder: Coder, Decoder, BodyDecoder {
                 return try decodeType(fieldValue?.dateFormatted(formatted), to: T.self)
             case .custom(let closure):
                 return try decodeType(closure(self), to: T.self)
+            default:
+                Log.warning("Unknown decoding strategy")
+                return try decodeType(fieldValue, to: T.self)
             }
         case is [Date].Type:
             switch dateDecoder {
@@ -241,6 +244,9 @@ public class QueryDecoder: Coder, Decoder, BodyDecoder {
                 else {
                     return try decodeType(dateArray, to: T.self)
                 }
+                default:
+                    Log.warning("Unknown decoding strategy")
+                    return try decodeType(fieldValue, to: T.self)
             }
         /// Strings
         case is String.Type:

--- a/Sources/KituraContracts/CodableQuery/QueryDecoder.swift
+++ b/Sources/KituraContracts/CodableQuery/QueryDecoder.swift
@@ -199,11 +199,11 @@ public class QueryDecoder: Coder, Decoder, BodyDecoder {
                 return try decodeType(Date(timeIntervalSince1970: (doubleValue)), to: T.self)
             case .iso8601:
                 if #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
-                guard let stringValue = fieldValue?.string else {return try decodeType(fieldValue, to: T.self)}
-                    guard let date = _iso8601Formatter.date(from: stringValue) else {
-                        throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Expected date string to be ISO8601-formatted."))
-                    }
-                    return try decodeType(date, to: T.self)
+                    guard let stringValue = fieldValue?.string else {return try decodeType(fieldValue, to: T.self)}
+                        guard let date = _iso8601Formatter.date(from: stringValue) else {
+                            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Expected date string to be ISO8601-formatted."))
+                        }
+                        return try decodeType(date, to: T.self)
                 } else {
                     fatalError("ISO8601DateFormatter is unavailable on this platform.")
                 }
@@ -224,7 +224,11 @@ public class QueryDecoder: Coder, Decoder, BodyDecoder {
             case .millisecondsSince1970:
                 return try decodeType(fieldValue?.dateArray(decoderStrategy: .millisecondsSince1970), to: T.self)
             case .iso8601:
-                return try decodeType(fieldValue?.dateArray(decoderStrategy: .iso8601), to: T.self)
+                if #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
+                    return try decodeType(fieldValue?.dateArray(decoderStrategy: .iso8601), to: T.self)
+                } else {
+                    fatalError("ISO8601DateFormatter is unavailable on this platform.")
+                }
             case .formatted(let formatter):
                 return try decodeType(fieldValue?.dateArray(formatter), to: T.self)
             case .custom(let closure):

--- a/Sources/KituraContracts/CodableQuery/QueryDecoder.swift
+++ b/Sources/KituraContracts/CodableQuery/QueryDecoder.swift
@@ -211,8 +211,6 @@ public class QueryDecoder: Coder, Decoder, BodyDecoder {
                 return try decodeType(fieldValue?.dateFormatted(formatted), to: T.self)
             case .custom(let closure):
                 return try decodeType(closure(self), to: T.self)
-            @unknown default:
-                fatalError()
             }
         case is [Date].Type:
             switch dateDecoder {
@@ -243,8 +241,6 @@ public class QueryDecoder: Coder, Decoder, BodyDecoder {
                 else {
                     return try decodeType(dateArray, to: T.self)
                 }
-            @unknown default:
-                fatalError()
             }
         /// Strings
         case is String.Type:

--- a/Sources/KituraContracts/CodableQuery/QueryDecoder.swift
+++ b/Sources/KituraContracts/CodableQuery/QueryDecoder.swift
@@ -65,7 +65,6 @@ public class QueryDecoder: Coder, Decoder, BodyDecoder {
      to use when decoding the specific date.
      */
     public var dateDecoder: JSONDecoder.DateDecodingStrategy
-
     /**
      Initializer with an empty dictionary for decoding from Data.
      */
@@ -211,7 +210,6 @@ public class QueryDecoder: Coder, Decoder, BodyDecoder {
             case .formatted(let formatted):
                 return try decodeType(fieldValue?.dateFormatted(formatted), to: T.self)
             case .custom(let closure):
-                
                 return try decodeType(closure(self), to: T.self)
             @unknown default:
                 fatalError()
@@ -229,7 +227,22 @@ public class QueryDecoder: Coder, Decoder, BodyDecoder {
             case .formatted(let formatter):
                 return try decodeType(fieldValue?.dateArrayFormatted(formatter), to: T.self)
             case .custom(let closure):
-                return try decodeType(closure(self), to: T.self)
+                // Initialise empty Date array
+                var dateArray: [Date] = []
+                var fieldValueArray = fieldValue?.split(separator: ",")
+                if fieldValueArray != nil {
+                    for _ in fieldValueArray! {
+                        // Call closure to decode value
+                        let date = try closure(self)
+                        dateArray.append(date)
+                        // Delete from array after use
+                        fieldValueArray!.removeFirst()
+                    }
+                    return try decodeType(dateArray, to: T.self)
+                }
+                else {
+                    return try decodeType(dateArray, to: T.self)
+                }
             @unknown default:
                 fatalError()
             }

--- a/Sources/KituraContracts/CodableQuery/QueryDecoder.swift
+++ b/Sources/KituraContracts/CodableQuery/QueryDecoder.swift
@@ -208,7 +208,7 @@ public class QueryDecoder: Coder, Decoder, BodyDecoder {
                     fatalError("ISO8601DateFormatter is unavailable on this platform.")
                 }
             case .formatted(let formatted):
-                return try decodeType(fieldValue?.dateFormatted(formatted), to: T.self)
+                return try decodeType(fieldValue?.date(formatted), to: T.self)
             case .custom(let closure):
                 return try decodeType(closure(self), to: T.self)
             default:
@@ -226,7 +226,7 @@ public class QueryDecoder: Coder, Decoder, BodyDecoder {
             case .iso8601:
                 return try decodeType(fieldValue?.dateArrayISO(), to: T.self)
             case .formatted(let formatter):
-                return try decodeType(fieldValue?.dateArrayFormatted(formatter), to: T.self)
+                return try decodeType(fieldValue?.dateArray(formatter), to: T.self)
             case .custom(let closure):
                 // Initialise empty Date array
                 var dateArray: [Date] = []

--- a/Sources/KituraContracts/CodableQuery/QueryDecoder.swift
+++ b/Sources/KituraContracts/CodableQuery/QueryDecoder.swift
@@ -60,6 +60,10 @@ public class QueryDecoder: Coder, Decoder, BodyDecoder {
      */
     public var dictionary: [String : String]
 
+    /**
+     A `JSONDecoder.DateDecodingStrategy` date decoder used to determine what strategy
+     to use when decoding the specific date.
+     */
     public var dateDecoder: JSONDecoder.DateDecodingStrategy
 
     /**

--- a/Sources/KituraContracts/CodableQuery/QueryDecoder.swift
+++ b/Sources/KituraContracts/CodableQuery/QueryDecoder.swift
@@ -206,10 +206,25 @@ public class QueryDecoder: Coder, Decoder, BodyDecoder {
                 return try decodeType(fieldValue?.dateFormatted(formatted), to: T.self)
             case .custom(let closure):
                 return try decodeType(closure(self), to: T.self)
+            @unknown default:
+                fatalError()
             }
         case is [Date].Type:
             switch dateDecoder {
-            return try decodeType(fieldValue?.dateArray(dateFormatter), to: T.self)
+            case .deferredToDate:
+                return try decodeType(fieldValue?.dateArrayDeferred(), to: T.self)
+            case .secondsSince1970:
+                return try decodeType(fieldValue?.dateArray1970(), to: T.self)
+            case .millisecondsSince1970:
+                return try decodeType(fieldValue?.dateArray1970M(), to: T.self)
+            case .iso8601:
+                return try decodeType(fieldValue?.dateArrayISO(), to: T.self)
+            case .formatted(let formatter):
+                return try decodeType(fieldValue?.dateArrayFormatted(formatter), to: T.self)
+            case .custom(_):
+                return print ("Test") as! T
+            @unknown default:
+                fatalError()
             }
         /// Strings
         case is String.Type:

--- a/Sources/KituraContracts/CodableQuery/QueryEncoder.swift
+++ b/Sources/KituraContracts/CodableQuery/QueryEncoder.swift
@@ -364,7 +364,10 @@ public class QueryEncoder: Coder, Encoder, BodyEncoder {
                         fatalError("ISO8601DateFormatter is unavailable on this platform.")
                     }
                 case .custom(let closure):
-                    print("Test")                }
+                    print("Test")
+                @unknown default:
+                    fatalError()
+                }
             case let fieldValue as [Date]:
                 let strs: [String] = fieldValue.map { encoder.dateFormatter.string(from: $0) }
                 encoder.dictionary[fieldName] = strs.joined(separator: ",")

--- a/Sources/KituraContracts/CodableQuery/QueryEncoder.swift
+++ b/Sources/KituraContracts/CodableQuery/QueryEncoder.swift
@@ -350,7 +350,7 @@ public class QueryEncoder: Coder, Encoder, BodyEncoder {
                 encoder.anyDictionary[fieldName] = fieldValue
             case .iso8601:
                 if #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
-                    encoder.dictionary[fieldName] = NSString(string: _iso8601Formatter.string(from: fieldValue)) as String
+                    encoder.dictionary[fieldName] = _iso8601Formatter.string(from: fieldValue)
                     encoder.anyDictionary[fieldName] = fieldValue
                 } else {
                     fatalError("ISO8601DateFormatter is unavailable on this platform.")
@@ -379,7 +379,7 @@ public class QueryEncoder: Coder, Encoder, BodyEncoder {
                 encoder.anyDictionary[fieldName] = fieldValue
             case .iso8601:
                 if #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
-                    let strs: [String] = fieldValue.map { NSString(string: _iso8601Formatter.string(from: $0)) as String }
+                    let strs: [String] = fieldValue.map { _iso8601Formatter.string(from: $0) }
                     encoder.dictionary[fieldName] = strs.joined(separator: ",")
                     encoder.anyDictionary[fieldName] = fieldValue
                 } else {

--- a/Sources/KituraContracts/CodableQuery/QueryEncoder.swift
+++ b/Sources/KituraContracts/CodableQuery/QueryEncoder.swift
@@ -60,7 +60,10 @@ public class QueryEncoder: Coder, Encoder, BodyEncoder {
      The coding user info key.
      */
     public var userInfo: [CodingUserInfoKey: Any] = [:]
-
+    /**
+     A `JSONDecoder.DateEncodingStrategy` date encoder used to determine what strategy
+     to use when encoding the specific date.
+     */
     public var dateEncoder: JSONEncoder.DateEncodingStrategy
 
     /**
@@ -322,7 +325,7 @@ public class QueryEncoder: Coder, Encoder, BodyEncoder {
             encoder.anyDictionary[fieldName] = fieldValue
         /// Strings
         case let fieldValue as String:
-            encoder.dictionary[fieldName] = fieldValue
+            encoder.dictionary[fieldName] =+= fieldValue
             encoder.anyDictionary[fieldName] = fieldValue
         case let fieldValue as [String]:
             encoder.dictionary[fieldName] = fieldValue.joined(separator: ",")
@@ -387,8 +390,8 @@ public class QueryEncoder: Coder, Encoder, BodyEncoder {
                 encoder.dictionary[fieldName] = strs.joined(separator: ",")
                 encoder.anyDictionary[fieldName] = fieldValue
             case .custom(let closure):
-                for (_, element) in fieldValue.enumerated() {
-                    _ = try closure(element, encoder)
+                for element in fieldValue {
+                    try closure(element, encoder)
                 }
             @unknown default:
                 fatalError()
@@ -480,3 +483,14 @@ public class QueryEncoder: Coder, Encoder, BodyEncoder {
         }
     }
 }
+
+infix operator =+=
+
+    func =+= (lhs: inout String?, rhs: String) {
+        if lhs != nil {
+            lhs = String("\(lhs!),\(rhs)")
+        } else {
+            lhs = rhs
+        }
+    }
+

--- a/Sources/KituraContracts/CodableQuery/QueryEncoder.swift
+++ b/Sources/KituraContracts/CodableQuery/QueryEncoder.swift
@@ -497,8 +497,8 @@ public class QueryEncoder: Coder, Encoder, BodyEncoder {
 // The '=+=' operator builds a comma-separated list of values for a given fieldName when encoding a [Date] that uses a custom formatting.
 infix operator =+=
     func =+= (lhs: inout String?, rhs: String) {
-        if lhs != nil {
-            lhs = String("\(lhs!),\(rhs)")
+        if let lhsValue = lhs {
+            lhs = lhsValue + "," + rhs
         } else {
             lhs = rhs
         }

--- a/Sources/KituraContracts/CodableQuery/QueryEncoder.swift
+++ b/Sources/KituraContracts/CodableQuery/QueryEncoder.swift
@@ -357,6 +357,8 @@ public class QueryEncoder: Coder, Encoder, BodyEncoder {
                 }
             case .custom(let closure):
                 try closure(fieldValue, encoder)
+            default:
+                Log.warning("Unknown encoding strategy")
             }
         case let fieldValue as [Date]:
             switch encoder.dateEncoder {
@@ -391,6 +393,8 @@ public class QueryEncoder: Coder, Encoder, BodyEncoder {
                 for element in fieldValue {
                     try closure(element, encoder)
                 }
+            default:
+            Log.warning("Unknown encoding strategy")
             }
         case let fieldValue as Operation:
             encoder.dictionary[fieldName] = fieldValue.getStringValue()

--- a/Sources/KituraContracts/CodableQuery/QueryEncoder.swift
+++ b/Sources/KituraContracts/CodableQuery/QueryEncoder.swift
@@ -159,7 +159,7 @@ public class QueryEncoder: Coder, Encoder, BodyEncoder {
     public func encode<T: Encodable>(_ value: T) throws -> [String : String] {
         let encoder = QueryEncoder()
         if let Q = T.self as? QueryParams.Type {
-        encoder.dateEncoder = Q.dateEncoder
+            encoder.dateEncoder = Q.dateEncoder
         }
         try value.encode(to: encoder)
         return encoder.dictionary
@@ -196,7 +196,7 @@ public class QueryEncoder: Coder, Encoder, BodyEncoder {
      ````
      */
     public func unkeyedContainer() -> UnkeyedEncodingContainer {
-        return UnkeyedContanier(encoder: self)
+        return UnkeyedContainer(encoder: self)
     }
     
     /**
@@ -208,7 +208,213 @@ public class QueryEncoder: Coder, Encoder, BodyEncoder {
      ````
      */
     public func singleValueContainer() -> SingleValueEncodingContainer {
-        return UnkeyedContanier(encoder: self)
+        return UnkeyedContainer(encoder: self)
+    }
+
+    internal func _encode<T: Encodable>(value: T) throws {
+        let encoder = self
+        let fieldName = Coder.getFieldName(from: encoder.codingPath)
+
+        switch value {
+        /// Ints
+        case let fieldValue as Int:
+            encoder.dictionary[fieldName] = String(fieldValue)
+            encoder.anyDictionary[fieldName] = fieldValue
+        case let fieldValue as Int8:
+            encoder.dictionary[fieldName] = String(fieldValue)
+            encoder.anyDictionary[fieldName] = fieldValue
+        case let fieldValue as Int16:
+            encoder.dictionary[fieldName] = String(fieldValue)
+            encoder.anyDictionary[fieldName] = fieldValue
+        case let fieldValue as Int32:
+            encoder.dictionary[fieldName] = String(fieldValue)
+            encoder.anyDictionary[fieldName] = fieldValue
+        case let fieldValue as Int64:
+            encoder.dictionary[fieldName] = String(fieldValue)
+            encoder.anyDictionary[fieldName] = fieldValue
+        /// Int Arrays
+        case let fieldValue as [Int]:
+            let strs: [String] = fieldValue.map { String($0) }
+            encoder.dictionary[fieldName] = strs.joined(separator: ",")
+            encoder.anyDictionary[fieldName] = fieldValue
+        case let fieldValue as [Int8]:
+            let strs: [String] = fieldValue.map { String($0) }
+            encoder.dictionary[fieldName] = strs.joined(separator: ",")
+            encoder.anyDictionary[fieldName] = fieldValue
+        case let fieldValue as [Int16]:
+            let strs: [String] = fieldValue.map { String($0) }
+            encoder.dictionary[fieldName] = strs.joined(separator: ",")
+            encoder.anyDictionary[fieldName] = fieldValue
+        case let fieldValue as [Int32]:
+            let strs: [String] = fieldValue.map { String($0) }
+            encoder.dictionary[fieldName] = strs.joined(separator: ",")
+            encoder.anyDictionary[fieldName] = fieldValue
+        case let fieldValue as [Int64]:
+            let strs: [String] = fieldValue.map { String($0) }
+            encoder.dictionary[fieldName] = strs.joined(separator: ",")
+            encoder.anyDictionary[fieldName] = fieldValue
+        /// UInts
+        case let fieldValue as UInt:
+            encoder.dictionary[fieldName] = String(fieldValue)
+            encoder.anyDictionary[fieldName] = fieldValue
+        /// Int Arrays
+        case let fieldValue as UInt8:
+            encoder.dictionary[fieldName] = String(fieldValue)
+            encoder.anyDictionary[fieldName] = fieldValue
+        /// Int Arrays
+        case let fieldValue as UInt16:
+            encoder.dictionary[fieldName] = String(fieldValue)
+            encoder.anyDictionary[fieldName] = fieldValue
+        /// Int Arrays
+        case let fieldValue as UInt32:
+            encoder.dictionary[fieldName] = String(fieldValue)
+            encoder.anyDictionary[fieldName] = fieldValue
+        /// Int Arrays
+        case let fieldValue as UInt64:
+            encoder.dictionary[fieldName] = String(fieldValue)
+            encoder.anyDictionary[fieldName] = fieldValue
+        /// Int Arrays
+        /// UInt Arrays
+        case let fieldValue as [UInt]:
+            let strs: [String] = fieldValue.map { String($0) }
+            encoder.dictionary[fieldName] = strs.joined(separator: ",")
+            encoder.anyDictionary[fieldName] = fieldValue
+        /// Int Arrays
+        case let fieldValue as [UInt8]:
+            let strs: [String] = fieldValue.map { String($0) }
+            encoder.dictionary[fieldName] = strs.joined(separator: ",")
+            encoder.anyDictionary[fieldName] = fieldValue
+        case let fieldValue as [UInt16]:
+            let strs: [String] = fieldValue.map { String($0) }
+            encoder.dictionary[fieldName] = strs.joined(separator: ",")
+            encoder.anyDictionary[fieldName] = fieldValue
+        case let fieldValue as [UInt32]:
+            let strs: [String] = fieldValue.map { String($0) }
+            encoder.dictionary[fieldName] = strs.joined(separator: ",")
+            encoder.anyDictionary[fieldName] = fieldValue
+        case let fieldValue as [UInt64]:
+            let strs: [String] = fieldValue.map { String($0) }
+            encoder.dictionary[fieldName] = strs.joined(separator: ",")
+            encoder.anyDictionary[fieldName] = fieldValue
+        /// Floats
+        case let fieldValue as Float:
+            encoder.dictionary[fieldName] = String(fieldValue)
+            encoder.anyDictionary[fieldName] = fieldValue
+        case let fieldValue as [Float]:
+            let strs: [String] = fieldValue.map { String($0) }
+            encoder.dictionary[fieldName] = strs.joined(separator: ",")
+            encoder.anyDictionary[fieldName] = fieldValue
+        /// Doubles
+        case let fieldValue as Double:
+            encoder.dictionary[fieldName] = String(fieldValue)
+            encoder.anyDictionary[fieldName] = fieldValue
+        case let fieldValue as [Double]:
+            let strs: [String] = fieldValue.map { String($0) }
+            encoder.dictionary[fieldName] = strs.joined(separator: ",")
+            encoder.anyDictionary[fieldName] = fieldValue
+        /// Bools
+        case let fieldValue as Bool:
+            encoder.dictionary[fieldName] = String(fieldValue)
+            encoder.anyDictionary[fieldName] = fieldValue
+        case let fieldValue as [Bool]:
+            let strs: [String] = fieldValue.map { String($0) }
+            encoder.dictionary[fieldName] = strs.joined(separator: ",")
+            encoder.anyDictionary[fieldName] = fieldValue
+        /// Strings
+        case let fieldValue as String:
+            encoder.dictionary[fieldName] = fieldValue
+            encoder.anyDictionary[fieldName] = fieldValue
+        case let fieldValue as [String]:
+            encoder.dictionary[fieldName] = fieldValue.joined(separator: ",")
+            encoder.anyDictionary[fieldName] = fieldValue
+        /// Dates
+        case let fieldValue as Date:
+            switch encoder.dateEncoder {
+            case .formatted(let formatter):
+                encoder.dictionary[fieldName] = formatter.string(from: fieldValue)
+                encoder.anyDictionary[fieldName] = fieldValue
+            case .deferredToDate:
+                let date = NSNumber(value: fieldValue.timeIntervalSinceReferenceDate)
+                encoder.dictionary[fieldName] = date.stringValue
+                encoder.anyDictionary[fieldName] = fieldValue
+            case .secondsSince1970:
+                let date = NSNumber(value: fieldValue.timeIntervalSince1970)
+                encoder.dictionary[fieldName] = date.stringValue
+                encoder.anyDictionary[fieldName] = fieldValue
+            case .millisecondsSince1970:
+                let date = NSNumber(value: 1000 * fieldValue.timeIntervalSince1970)
+                encoder.dictionary[fieldName] = date.stringValue
+                encoder.anyDictionary[fieldName] = fieldValue
+            case .iso8601:
+                if #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
+                    encoder.dictionary[fieldName] = NSString(string: _iso8601Formatter.string(from: fieldValue)) as String
+                    encoder.anyDictionary[fieldName] = fieldValue
+                } else {
+                    fatalError("ISO8601DateFormatter is unavailable on this platform.")
+                }
+            case .custom(let closure):
+                try closure(fieldValue, encoder)
+            @unknown default:
+                fatalError()
+            }
+        case let fieldValue as [Date]:
+            switch encoder.dateEncoder {
+            case .deferredToDate:
+                let dbs: [NSNumber] = fieldValue.map { NSNumber(value: $0.timeIntervalSinceReferenceDate) }
+                let strs: [String] = dbs.map { ($0).stringValue}
+                encoder.dictionary[fieldName] = strs.joined(separator: ",")
+                encoder.anyDictionary[fieldName] = fieldValue
+            case .secondsSince1970:
+                let dbs: [NSNumber] = fieldValue.map { NSNumber(value: $0.timeIntervalSince1970) }
+                let strs: [String] = dbs.map { ($0).stringValue}
+                encoder.dictionary[fieldName] = strs.joined(separator: ",")
+                encoder.anyDictionary[fieldName] = fieldValue
+            case .millisecondsSince1970:
+                let dbs: [NSNumber] = fieldValue.map { NSNumber(value: ($0.timeIntervalSince1970)/1000) }
+                let strs: [String] = dbs.map { ($0).stringValue}
+                encoder.dictionary[fieldName] = strs.joined(separator: ",")
+                encoder.anyDictionary[fieldName] = fieldValue
+            case .iso8601:
+                if #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
+                    let strs: [String] = fieldValue.map { NSString(string: _iso8601Formatter.string(from: $0)) as String }
+                    encoder.dictionary[fieldName] = strs.joined(separator: ",")
+                    encoder.anyDictionary[fieldName] = fieldValue
+                } else {
+                    fatalError("ISO8601DateFormatter is unavailable on this platform.")
+                }
+            case .formatted(let formatter):
+                let strs: [String] = fieldValue.map { formatter.string(from: $0) }
+                encoder.dictionary[fieldName] = strs.joined(separator: ",")
+                encoder.anyDictionary[fieldName] = fieldValue
+            case .custom(_):
+                print("test")
+            @unknown default:
+                fatalError()
+            }
+        case let fieldValue as Operation:
+            encoder.dictionary[fieldName] = fieldValue.getStringValue()
+            encoder.anyDictionary[fieldName] = fieldValue
+        case let fieldValue as Ordering:
+            encoder.dictionary[fieldName] = fieldValue.getStringValue()
+            encoder.anyDictionary[fieldName] = fieldValue
+        case let fieldValue as Pagination:
+            encoder.dictionary[fieldName] = fieldValue.getStringValue()
+            encoder.anyDictionary[fieldName] = fieldValue
+        default:
+            if fieldName.isEmpty {
+                encoder.dictionary = [:]   // Make encoder instance reusable
+                encoder.anyDictionary = [:]   // Make encoder instance reusable
+                try value.encode(to: encoder)
+            } else {
+                do {
+                    let jsonData = try JSONEncoder().encode(value)
+                    encoder.dictionary[fieldName] = String(data: jsonData, encoding: .utf8)
+                    encoder.anyDictionary[fieldName] = jsonData
+                } catch let error {
+                    throw encoder.encodingError(value, underlyingError: error)
+                }
+            }
+        }
     }
 
     internal func encodingError(_ value: Any, underlyingError: Swift.Error?) -> EncodingError {
@@ -224,178 +430,7 @@ public class QueryEncoder: Coder, Encoder, BodyEncoder {
         func encode<T>(_ value: T, forKey key: Key) throws where T : Encodable {
             self.encoder.codingPath.append(key)
             defer { self.encoder.codingPath.removeLast() }
-            let fieldName = Coder.getFieldName(from: self.encoder.codingPath)
-
-            switch value {
-            /// Ints
-            case let fieldValue as Int:
-                encoder.dictionary[fieldName] = String(fieldValue)
-                encoder.anyDictionary[fieldName] = fieldValue
-            case let fieldValue as Int8:
-                encoder.dictionary[fieldName] = String(fieldValue)
-                encoder.anyDictionary[fieldName] = fieldValue
-            case let fieldValue as Int16:
-                encoder.dictionary[fieldName] = String(fieldValue)
-                encoder.anyDictionary[fieldName] = fieldValue
-            case let fieldValue as Int32:
-                encoder.dictionary[fieldName] = String(fieldValue)
-                encoder.anyDictionary[fieldName] = fieldValue
-            case let fieldValue as Int64:
-                encoder.dictionary[fieldName] = String(fieldValue)
-                encoder.anyDictionary[fieldName] = fieldValue
-            /// Int Arrays
-            case let fieldValue as [Int]:
-                let strs: [String] = fieldValue.map { String($0) }
-                encoder.dictionary[fieldName] = strs.joined(separator: ",")
-                encoder.anyDictionary[fieldName] = fieldValue
-            case let fieldValue as [Int8]:
-                let strs: [String] = fieldValue.map { String($0) }
-                encoder.dictionary[fieldName] = strs.joined(separator: ",")
-                encoder.anyDictionary[fieldName] = fieldValue
-            case let fieldValue as [Int16]:
-                let strs: [String] = fieldValue.map { String($0) }
-                encoder.dictionary[fieldName] = strs.joined(separator: ",")
-                encoder.anyDictionary[fieldName] = fieldValue
-            case let fieldValue as [Int32]:
-                let strs: [String] = fieldValue.map { String($0) }
-                encoder.dictionary[fieldName] = strs.joined(separator: ",")
-                encoder.anyDictionary[fieldName] = fieldValue
-            case let fieldValue as [Int64]:
-                let strs: [String] = fieldValue.map { String($0) }
-                encoder.dictionary[fieldName] = strs.joined(separator: ",")
-                encoder.anyDictionary[fieldName] = fieldValue
-            /// UInts
-            case let fieldValue as UInt:
-                encoder.dictionary[fieldName] = String(fieldValue)
-                encoder.anyDictionary[fieldName] = fieldValue
-            /// Int Arrays
-            case let fieldValue as UInt8:
-                encoder.dictionary[fieldName] = String(fieldValue)
-                encoder.anyDictionary[fieldName] = fieldValue
-            /// Int Arrays
-            case let fieldValue as UInt16:
-                encoder.dictionary[fieldName] = String(fieldValue)
-                encoder.anyDictionary[fieldName] = fieldValue
-            /// Int Arrays
-            case let fieldValue as UInt32:
-                encoder.dictionary[fieldName] = String(fieldValue)
-                encoder.anyDictionary[fieldName] = fieldValue
-            /// Int Arrays
-            case let fieldValue as UInt64:
-                encoder.dictionary[fieldName] = String(fieldValue)
-                encoder.anyDictionary[fieldName] = fieldValue
-            /// Int Arrays
-            /// UInt Arrays
-            case let fieldValue as [UInt]:
-                let strs: [String] = fieldValue.map { String($0) }
-                encoder.dictionary[fieldName] = strs.joined(separator: ",")
-                encoder.anyDictionary[fieldName] = fieldValue
-            /// Int Arrays
-            case let fieldValue as [UInt8]:
-                let strs: [String] = fieldValue.map { String($0) }
-                encoder.dictionary[fieldName] = strs.joined(separator: ",")
-                encoder.anyDictionary[fieldName] = fieldValue
-            case let fieldValue as [UInt16]:
-                let strs: [String] = fieldValue.map { String($0) }
-                encoder.dictionary[fieldName] = strs.joined(separator: ",")
-                encoder.anyDictionary[fieldName] = fieldValue
-            case let fieldValue as [UInt32]:
-                let strs: [String] = fieldValue.map { String($0) }
-                encoder.dictionary[fieldName] = strs.joined(separator: ",")
-                encoder.anyDictionary[fieldName] = fieldValue
-            case let fieldValue as [UInt64]:
-                let strs: [String] = fieldValue.map { String($0) }
-                encoder.dictionary[fieldName] = strs.joined(separator: ",")
-                encoder.anyDictionary[fieldName] = fieldValue
-            /// Floats
-            case let fieldValue as Float:
-                encoder.dictionary[fieldName] = String(fieldValue)
-                encoder.anyDictionary[fieldName] = fieldValue
-            case let fieldValue as [Float]:
-                let strs: [String] = fieldValue.map { String($0) }
-                encoder.dictionary[fieldName] = strs.joined(separator: ",")
-                encoder.anyDictionary[fieldName] = fieldValue
-            /// Doubles
-            case let fieldValue as Double:
-                encoder.dictionary[fieldName] = String(fieldValue)
-                encoder.anyDictionary[fieldName] = fieldValue
-            case let fieldValue as [Double]:
-                let strs: [String] = fieldValue.map { String($0) }
-                encoder.dictionary[fieldName] = strs.joined(separator: ",")
-                encoder.anyDictionary[fieldName] = fieldValue
-            /// Bools
-            case let fieldValue as Bool:
-                encoder.dictionary[fieldName] = String(fieldValue)
-                encoder.anyDictionary[fieldName] = fieldValue
-            case let fieldValue as [Bool]:
-                let strs: [String] = fieldValue.map { String($0) }
-                encoder.dictionary[fieldName] = strs.joined(separator: ",")
-                encoder.anyDictionary[fieldName] = fieldValue
-            /// Strings
-            case let fieldValue as String:
-                encoder.dictionary[fieldName] = fieldValue
-                encoder.anyDictionary[fieldName] = fieldValue
-            case let fieldValue as [String]:
-                encoder.dictionary[fieldName] = fieldValue.joined(separator: ",")
-                encoder.anyDictionary[fieldName] = fieldValue
-            /// Dates
-            case let fieldValue as Date:
-                switch encoder.dateEncoder {
-                case .formatted(let formatter):
-                    encoder.dictionary[fieldName] = formatter.string(from: fieldValue)
-                    encoder.anyDictionary[fieldName] = fieldValue
-                case .deferredToDate:
-                    let date = NSNumber(value: fieldValue.timeIntervalSinceReferenceDate)
-                    encoder.dictionary[fieldName] = date.stringValue
-                    encoder.anyDictionary[fieldName] = fieldValue
-                case .secondsSince1970:
-                    let date = NSNumber(value: fieldValue.timeIntervalSince1970)
-                    encoder.dictionary[fieldName] = date.stringValue
-                    encoder.anyDictionary[fieldName] = fieldValue
-                case .millisecondsSince1970:
-                    let date = NSNumber(value: 1000 * fieldValue.timeIntervalSince1970)
-                    encoder.dictionary[fieldName] = date.stringValue
-                    encoder.anyDictionary[fieldName] = fieldValue
-                case .iso8601:
-                    if #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
-                        encoder.dictionary[fieldName] = NSString(string: _iso8601Formatter.string(from: fieldValue)) as String
-                        encoder.anyDictionary[fieldName] = fieldValue
-                    } else {
-                        fatalError("ISO8601DateFormatter is unavailable on this platform.")
-                    }
-                case .custom(let closure):
-                    print("Test")
-                @unknown default:
-                    fatalError()
-                }
-            case let fieldValue as [Date]:
-                let strs: [String] = fieldValue.map { encoder.dateFormatter.string(from: $0) }
-                encoder.dictionary[fieldName] = strs.joined(separator: ",")
-                encoder.anyDictionary[fieldName] = fieldValue
-            case let fieldValue as Operation:
-                encoder.dictionary[fieldName] = fieldValue.getStringValue()
-                encoder.anyDictionary[fieldName] = fieldValue
-            case let fieldValue as Ordering:
-                encoder.dictionary[fieldName] = fieldValue.getStringValue()
-                encoder.anyDictionary[fieldName] = fieldValue
-            case let fieldValue as Pagination:
-                encoder.dictionary[fieldName] = fieldValue.getStringValue()
-                encoder.anyDictionary[fieldName] = fieldValue
-            default:
-                if fieldName.isEmpty {
-                    encoder.dictionary = [:]   // Make encoder instance reusable
-                    encoder.anyDictionary = [:]   // Make encoder instance reusable
-                    try value.encode(to: encoder)
-                } else {
-                    do {
-                        let jsonData = try JSONEncoder().encode(value)
-                        encoder.dictionary[fieldName] = String(data: jsonData, encoding: .utf8)
-                        encoder.anyDictionary[fieldName] = jsonData
-                    } catch let error {
-                        throw encoder.encodingError(value, underlyingError: error)
-                    }
-                }
-            }
+            try encoder._encode(value: value)
         }
 
         func encodeNil(forKey: Key) throws {}
@@ -417,7 +452,7 @@ public class QueryEncoder: Coder, Encoder, BodyEncoder {
         }
     }
 
-    private struct UnkeyedContanier: UnkeyedEncodingContainer, SingleValueEncodingContainer {
+    private struct UnkeyedContainer: UnkeyedEncodingContainer, SingleValueEncodingContainer {
         var encoder: QueryEncoder
 
         var codingPath: [CodingKey] { return [] }
@@ -439,7 +474,7 @@ public class QueryEncoder: Coder, Encoder, BodyEncoder {
         func encodeNil() throws {}
 
         func encode<T>(_ value: T) throws where T : Encodable {
-            let _: [String : String] = try encoder.encode(value)
+            try encoder._encode(value: value)
         }
     }
 }

--- a/Sources/KituraContracts/CodableQuery/QueryEncoder.swift
+++ b/Sources/KituraContracts/CodableQuery/QueryEncoder.swift
@@ -357,8 +357,6 @@ public class QueryEncoder: Coder, Encoder, BodyEncoder {
                 }
             case .custom(let closure):
                 try closure(fieldValue, encoder)
-            @unknown default:
-                fatalError()
             }
         case let fieldValue as [Date]:
             switch encoder.dateEncoder {
@@ -393,8 +391,6 @@ public class QueryEncoder: Coder, Encoder, BodyEncoder {
                 for element in fieldValue {
                     try closure(element, encoder)
                 }
-            @unknown default:
-                fatalError()
             }
         case let fieldValue as Operation:
             encoder.dictionary[fieldName] = fieldValue.getStringValue()

--- a/Sources/KituraContracts/CodableQuery/QueryEncoder.swift
+++ b/Sources/KituraContracts/CodableQuery/QueryEncoder.swift
@@ -386,8 +386,10 @@ public class QueryEncoder: Coder, Encoder, BodyEncoder {
                 let strs: [String] = fieldValue.map { formatter.string(from: $0) }
                 encoder.dictionary[fieldName] = strs.joined(separator: ",")
                 encoder.anyDictionary[fieldName] = fieldValue
-            case .custom(_):
-                print("test")
+            case .custom(let closure):
+                for (_, element) in fieldValue.enumerated() {
+                    _ = try closure(element, encoder)
+                }
             @unknown default:
                 fatalError()
             }
@@ -478,10 +480,3 @@ public class QueryEncoder: Coder, Encoder, BodyEncoder {
         }
     }
 }
-
-@available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
-public var _iso8601Formatter: ISO8601DateFormatter = {
-let formatter = ISO8601DateFormatter()
-    formatter.formatOptions = .withInternetDateTime
-return formatter
-}()

--- a/Sources/KituraContracts/Contracts.swift
+++ b/Sources/KituraContracts/Contracts.swift
@@ -524,17 +524,17 @@ extension RequestError {
  */
 public protocol QueryParams: Codable {
 
-    static var dateDecoder: JSONDecoder.DateDecodingStrategy { get }
-    static var dateEncoder: JSONEncoder.DateEncodingStrategy { get }
+    static var dateDecodingStrategy: JSONDecoder.DateDecodingStrategy { get }
+    static var dateEncodingStrategy: JSONEncoder.DateEncodingStrategy { get }
 }
 
 extension QueryParams {
 
-    public static var dateDecoder : JSONDecoder.DateDecodingStrategy {
+    static var dateDecodingStrategy : JSONDecoder.DateDecodingStrategy {
         return .formatted(Coder().dateFormatter)
     }
 
-    public static var dateEncoder: JSONEncoder.DateEncodingStrategy {
+    static var dateEncodingStrategy: JSONEncoder.DateEncodingStrategy {
         return .formatted(Coder().dateFormatter)
     }
 

--- a/Sources/KituraContracts/Contracts.swift
+++ b/Sources/KituraContracts/Contracts.swift
@@ -523,6 +523,21 @@ extension RequestError {
  - All other non-optional types throw a decoding error
  */
 public protocol QueryParams: Codable {
+
+    static var dateDecoder: JSONDecoder.DateDecodingStrategy { get }
+    static var dateEncoder: JSONEncoder.DateEncodingStrategy { get }
+}
+
+extension QueryParams {
+
+    public static var dateDecoder : JSONDecoder.DateDecodingStrategy {
+        return .formatted(Coder().dateFormatter)
+    }
+
+    public static var dateEncoder: JSONEncoder.DateEncodingStrategy {
+        return .formatted(Coder().dateFormatter)
+    }
+
 }
 
 /**

--- a/Sources/KituraContracts/Contracts.swift
+++ b/Sources/KituraContracts/Contracts.swift
@@ -524,13 +524,46 @@ extension RequestError {
  */
 public protocol QueryParams: Codable {
 
+    /**
+     The decoding strategy for Dates.
+     The variable can be defined within your QueryParams object and tells the `QueryDecoder` how dates should be decoded.  The enum used for the DateDecodingStrategy is the same one found in the `JSONDecoder`.
+     ### Usage Example: ###
+     ```swift
+     struct MyQuery: QueryParams {
+        let date: Date
+        static let dateDecodingStrategy: JSONDecoder.DateDecodingStrategy = .iso8601
+        static let dateEncodingStrategy: JSONEncoder.DateEncodingStrategy = .iso8601
+     }
+
+     let queryParams = ["date": "2019-09-06T10:14:41+0000"]
+
+     let query = try QueryDecoder(dictionary: queryParams).decode(MyQuery.self)
+     ```
+     */
     static var dateDecodingStrategy: JSONDecoder.DateDecodingStrategy { get }
+
+    /**
+       The encoding strategy for Dates.
+       The variable would be defined within your QueryParams object and tells the `QueryEncoder` how dates should be encoded.  The enum used for the DateEncodingStrategy is the same one found in the `JSONEncoder`.
+      ### Usage Example: ###
+      ```swift
+      struct MyQuery: QueryParams {
+         let date: Date
+         static let dateDecodingStrategy: JSONDecoder.DateDecodingStrategy = .iso8601
+         static let dateEncodingStrategy: JSONEncoder.DateEncodingStrategy = .iso8601
+      }
+
+     let query = MyQuery(date: Date(timeIntervalSinceNow: 0))
+
+     let myQueryDict: [String: String] = try QueryEncoder().encode(query)
+     ```
+      */
     static var dateEncodingStrategy: JSONEncoder.DateEncodingStrategy { get }
 }
 
 extension QueryParams {
 
-    static var dateDecodingStrategy : JSONDecoder.DateDecodingStrategy {
+    static var dateDecodingStrategy: JSONDecoder.DateDecodingStrategy {
         return .formatted(Coder().dateFormatter)
     }
 

--- a/Tests/KituraContractsTests/QueryCoderTests.swift
+++ b/Tests/KituraContractsTests/QueryCoderTests.swift
@@ -158,8 +158,8 @@ class QueryCoderTests: XCTestCase {
 
     struct Query1970: QueryParams, Equatable {
         public let dateField: Date
-        static let dateDecoder: JSONDecoder.DateDecodingStrategy = .secondsSince1970
-        static let dateEncoder: JSONEncoder.DateEncodingStrategy = .secondsSince1970
+        static let dateDecodingStrategy: JSONDecoder.DateDecodingStrategy = .secondsSince1970
+        static let dateEncodingStrategy: JSONEncoder.DateEncodingStrategy = .secondsSince1970
         public static func ==(lhs: Query1970, rhs: Query1970) -> Bool {
             return lhs.dateField == rhs.dateField
         }
@@ -167,8 +167,8 @@ class QueryCoderTests: XCTestCase {
 
     struct QueryISO: QueryParams, Equatable {
         public let dateField: Date
-        static let dateDecoder: JSONDecoder.DateDecodingStrategy = .iso8601
-        static let dateEncoder: JSONEncoder.DateEncodingStrategy = .iso8601
+        static let dateDecodingStrategy: JSONDecoder.DateDecodingStrategy = .iso8601
+        static let dateEncodingStrategy: JSONEncoder.DateEncodingStrategy = .iso8601
         public static func ==(lhs: QueryISO, rhs: QueryISO) -> Bool {
             return lhs.dateField == rhs.dateField
         }
@@ -176,7 +176,7 @@ class QueryCoderTests: XCTestCase {
 
     struct QueryCustom: QueryParams, Equatable {
         public let dateField: Date
-        static let dateDecoder: JSONDecoder.DateDecodingStrategy = .custom { decoder in
+        static let dateDecodingStrategy: JSONDecoder.DateDecodingStrategy = .custom { decoder in
             // pull out the number of days from Codable
             let container = try decoder.singleValueContainer()
             let numberOfDays = try container.decode(Int.self)
@@ -190,7 +190,7 @@ class QueryCoderTests: XCTestCase {
             let calendar = Calendar(identifier: .gregorian)
             return calendar.date(byAdding: components, to: startDate) ?? Date()
         }
-        static let dateEncoder: JSONEncoder.DateEncodingStrategy = .custom { (date, encoder) in
+        static let dateEncodingStrategy: JSONEncoder.DateEncodingStrategy = .custom { (date, encoder) in
 
             let calendar = Calendar(identifier: .gregorian)
             let startDate = Date(timeIntervalSince1970: 0)
@@ -221,8 +221,8 @@ class QueryCoderTests: XCTestCase {
     struct QueryFormatted: QueryParams, Equatable {
 
         public let dateField: Date
-        static let dateDecoder: JSONDecoder.DateDecodingStrategy = .formatted(AlternateFormatter().altFormatter)
-        static let dateEncoder: JSONEncoder.DateEncodingStrategy = .formatted(AlternateFormatter().altFormatter)
+        static let dateDecodingStrategy: JSONDecoder.DateDecodingStrategy = .formatted(AlternateFormatter().altFormatter)
+        static let dateEncodingStrategy: JSONEncoder.DateEncodingStrategy = .formatted(AlternateFormatter().altFormatter)
         public static func ==(lhs: QueryFormatted, rhs: QueryFormatted) -> Bool {
             return lhs.dateField == rhs.dateField
         }
@@ -231,7 +231,7 @@ class QueryCoderTests: XCTestCase {
     struct QueryCustomArray: QueryParams, Equatable {
 
         public let dateField: [Date]
-        static let dateDecoder: JSONDecoder.DateDecodingStrategy = .custom { decoder in
+        static let dateDecodingStrategy: JSONDecoder.DateDecodingStrategy = .custom { decoder in
             // pull out the number of days from Codable
             let container = try decoder.singleValueContainer()
             let numberOfDaysArray = try container.decode([Int].self)
@@ -246,7 +246,7 @@ class QueryCoderTests: XCTestCase {
             let calendar = Calendar(identifier: .gregorian)
             return calendar.date(byAdding: components, to: startDate) ?? Date()
         }
-        static let dateEncoder: JSONEncoder.DateEncodingStrategy = .custom { (date, encoder) in
+        static let dateEncodingStrategy: JSONEncoder.DateEncodingStrategy = .custom { (date, encoder) in
 
             let calendar = Calendar(identifier: .gregorian)
             let startDate = Date(timeIntervalSince1970: 0)

--- a/Tests/KituraContractsTests/QueryCoderTests.swift
+++ b/Tests/KituraContractsTests/QueryCoderTests.swift
@@ -197,9 +197,9 @@ class QueryCoderTests: XCTestCase {
             let endDate = date
             let components = calendar.dateComponents([.day], from: startDate, to: endDate)
             let days = components.day
-            let stringData = String(days!)
+            let intData = Int(days!)
             var container = encoder.singleValueContainer()
-            try container.encode(stringData)
+            try container.encode(intData)
 
         }
         public static func ==(lhs: QueryCustom, rhs: QueryCustom) -> Bool {
@@ -253,9 +253,9 @@ class QueryCoderTests: XCTestCase {
             let endDate = date
             let components = calendar.dateComponents([.day], from: startDate, to: endDate)
             let days = components.day
-            let stringData = String(days!)
+            let intData = Int(days!)
             var container = encoder.singleValueContainer()
-            try container.encode(stringData)
+            try container.encode(intData)
 
         }
         public static func ==(lhs: QueryCustomArray, rhs: QueryCustomArray) -> Bool {
@@ -574,7 +574,10 @@ class QueryCoderTests: XCTestCase {
 
     func testISOEncode() {
 
-        let query = QueryISO(dateField: _iso8601Formatter.date(from: "2019-09-06T10:14:41+0000")!)
+        guard let dateString = _iso8601Formatter.date(from: "2019-09-06T10:14:41+0000") else {
+            return XCTFail("Date could not be formatted")
+        }
+        let query = QueryISO(dateField: dateString)
 
         guard let myQueryDict: [String: String] = try? QueryEncoder().encode(query) else {
             XCTFail("Failed to encode query to [String: String]")
@@ -789,6 +792,38 @@ class QueryCoderTests: XCTestCase {
 
     }
 
+    //This tests the first code example in the QueryParams struct
+    func testExample1() {
+        struct MyQuery: QueryParams {
+           let date: Date
+           static let dateDecodingStrategy: JSONDecoder.DateDecodingStrategy = .iso8601
+           static let dateEncodingStrategy: JSONEncoder.DateEncodingStrategy = .iso8601
+        }
+
+        let queryParams = ["date": "2019-09-06T10:14:41+0000"]
+
+        XCTAssertNoThrow(try QueryDecoder(dictionary: queryParams).decode(MyQuery.self))
+    }
+
+    //This tests the second code example in the QueryParams struct
+    func testExample2() {
+        do {
+            struct MyQuery: QueryParams {
+                let date: Date
+                static let dateDecodingStrategy: JSONDecoder.DateDecodingStrategy = .iso8601
+                static let dateEncodingStrategy: JSONEncoder.DateEncodingStrategy = .iso8601
+            }
+
+            let query = MyQuery(date: Date(timeIntervalSinceNow: 0))
+
+            let myQueryDict: [String: String] = try QueryEncoder().encode(query)
+            XCTAssertNotNil(myQueryDict["date"])
+        } catch {
+            XCTFail("\(error)")
+        }
+
+    }
+
 
     func testCycle() {
         let myInts = MyInts(intField: 1, int8Field: 2, int16Field: 3, int32Field: 4, int64Field: 5, uintField: 6, uint8Field: 7, uint16Field: 8, uint32Field: 9, uint64Field: 10)
@@ -860,4 +895,5 @@ class QueryCoderTests: XCTestCase {
         
         XCTAssertEqual(myQuery2, obj)
     }
+    
 }

--- a/Tests/KituraContractsTests/QueryCoderTests.swift
+++ b/Tests/KituraContractsTests/QueryCoderTests.swift
@@ -33,6 +33,8 @@ class QueryCoderTests: XCTestCase {
             ("testCustomEncode", testCustomEncode),
             ("testFormattedDecode", testFormattedDecode),
             ("testFormattedEncode", testFormattedEncode),
+            ("testCustomArrayDecode", testCustomArrayDecode),
+            ("testCustomArrayEncode", testCustomArrayEncode),
             ("testCycle", testCycle),
             ("testIllegalInt", testIllegalInt),
         ]

--- a/Tests/KituraContractsTests/QueryCoderTests.swift
+++ b/Tests/KituraContractsTests/QueryCoderTests.swift
@@ -300,15 +300,15 @@ class QueryCoderTests: XCTestCase {
       pagination: Pagination(start: 8, size: 14)
     )
 
-    let expected1970Dict = ["dateField": "1567684372"]
-    let expected1970String = "?dateField=1567684372"
+    let expected1970Dict = ["dateField": "1567684372.1"]
+    let expected1970String = "?dateField=1567684372.1"
     var expectedData1970: Data {
         let droppedQuestionMark = String(expected1970String.dropFirst())
         return droppedQuestionMark.data(using: .utf8)!
         }
-    let expected1970DateStr = "1567684372"
-    let expected1970Date = Date(timeIntervalSince1970: 1567684372)
-    let expectedQuery1970 = Query1970(dateField: Date(timeIntervalSince1970: 1567684372))
+    let expected1970DateStr = "1567684372.1"
+    let expected1970Date = Date(timeIntervalSince1970: 1567684372.1)
+    let expectedQuery1970 = Query1970(dateField: Date(timeIntervalSince1970: 1567684372.1))
 
     let expectedISODict = ["dateField": "2019-09-06T10:14:41+0000"]
     let expectedISOString = "?dateField=2019-09-06T10:14:41%2B0000"
@@ -516,14 +516,14 @@ class QueryCoderTests: XCTestCase {
 
     func test1970Encode() {
 
-        let query = Query1970(dateField: Date(timeIntervalSince1970: 1567684372))
+        let query = Query1970(dateField: Date(timeIntervalSince1970: 1567684372.1))
 
         guard let myQueryDict: [String: String] = try? QueryEncoder().encode(query) else {
             XCTFail("Failed to encode query to [String: String]")
             return
         }
 
-        XCTAssertEqual(myQueryDict["dateField"], "1567684372")
+        XCTAssertEqual(myQueryDict["dateField"], "1567684372.1")
 
         guard let myQueryStr: String = try? QueryEncoder().encode(query) else {
             XCTFail("Failed to encode query to String")
@@ -549,7 +549,7 @@ class QueryCoderTests: XCTestCase {
             return
         }
 
-        let queryItems = [ URLQueryItem(name: "dateField", value: "1567684372")]
+        let queryItems = [ URLQueryItem(name: "dateField", value: "1567684372.1")]
         XCTAssertEqual(queryItems, myURLQueryItems)
 
     }

--- a/Tests/KituraContractsTests/StringExtensionTests.swift
+++ b/Tests/KituraContractsTests/StringExtensionTests.swift
@@ -51,7 +51,7 @@ class StringExtensionsTests: XCTestCase {
         XCTAssertEqual("3.0".double, Double(3.0))
         XCTAssertEqual("4.0".float, Float(4.0))
         XCTAssertEqual("true".boolean, true)
-        XCTAssertEqual(d1.date(fm), fm.date(from: d1))
+        XCTAssertEqual(d1.dateFormatted(fm), fm.date(from: d1))
 
         let strArray = "string1,string2,string3"
         let intArray = "1,2,3"

--- a/Tests/KituraContractsTests/StringExtensionTests.swift
+++ b/Tests/KituraContractsTests/StringExtensionTests.swift
@@ -85,11 +85,11 @@ class StringExtensionsTests: XCTestCase {
         XCTAssertEqual(pointIntArray.floatArray!, [Float(1.0), Float(2.0), Float(3.0)])
         XCTAssertEqual("true,false,true".booleanArray!, [true, false, true])
         XCTAssertEqual("\(d1),\(d2),\(d3)".dateArrayFormatted(fm)!, [fm.date(from: d1)!, fm.date(from: d2)!, fm.date(from: d3)!])
-        XCTAssertEqual("\(dSeventy1),\(dSeventy2),\(dSeventy3)".dateArray1970(), [Date(timeIntervalSince1970: dSeventy1), Date(timeIntervalSince1970: dSeventy2), Date(timeIntervalSince1970: dSeventy3)])
-        XCTAssertEqual("\(dSeventy1),\(dSeventy2),\(dSeventy3)".dateArray1970M(), [Date(timeIntervalSince1970: dSeventy1/1000), Date(timeIntervalSince1970: dSeventy2/1000), Date(timeIntervalSince1970: dSeventy3/1000)])
+        XCTAssertEqual("\(dSeventy1),\(dSeventy2),\(dSeventy3)".dateArray1970()!, [Date(timeIntervalSince1970: dSeventy1), Date(timeIntervalSince1970: dSeventy2), Date(timeIntervalSince1970: dSeventy3)])
+        XCTAssertEqual("\(dSeventy1),\(dSeventy2),\(dSeventy3)".dateArray1970M()!, [Date(timeIntervalSince1970: dSeventy1/1000), Date(timeIntervalSince1970: dSeventy2/1000), Date(timeIntervalSince1970: dSeventy3/1000)])
         if #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
-        XCTAssertEqual("\(dISO1),\(dISO2),\(dISO3)".dateArrayISO(), [_iso8601Formatter.date(from: dISO1)!, _iso8601Formatter.date(from: dISO2)!, _iso8601Formatter.date(from: dISO3)!])
+        XCTAssertEqual("\(dISO1),\(dISO2),\(dISO3)".dateArrayISO()!, [_iso8601Formatter.date(from: dISO1)!, _iso8601Formatter.date(from: dISO2)!, _iso8601Formatter.date(from: dISO3)!])
         }
-        XCTAssertEqual("\(dDeferred1),\(dDeferred2),\(dDeferred3)".dateArrayDeferred(), [Date(timeIntervalSinceReferenceDate: dDeferred1), Date(timeIntervalSinceReferenceDate: dDeferred2), Date(timeIntervalSinceReferenceDate: dDeferred3)])
+        XCTAssertEqual("\(dDeferred1),\(dDeferred2),\(dDeferred3)".dateArrayDeferred()!, [Date(timeIntervalSinceReferenceDate: dDeferred1), Date(timeIntervalSinceReferenceDate: dDeferred2), Date(timeIntervalSinceReferenceDate: dDeferred3)])
     }
 }

--- a/Tests/KituraContractsTests/StringExtensionTests.swift
+++ b/Tests/KituraContractsTests/StringExtensionTests.swift
@@ -85,11 +85,11 @@ class StringExtensionsTests: XCTestCase {
         XCTAssertEqual(pointIntArray.floatArray!, [Float(1.0), Float(2.0), Float(3.0)])
         XCTAssertEqual("true,false,true".booleanArray!, [true, false, true])
         XCTAssertEqual("\(d1),\(d2),\(d3)".dateArray(fm)!, [fm.date(from: d1)!, fm.date(from: d2)!, fm.date(from: d3)!])
-        XCTAssertEqual("\(dSeventy1),\(dSeventy2),\(dSeventy3)".dateArray1970()!, [Date(timeIntervalSince1970: dSeventy1), Date(timeIntervalSince1970: dSeventy2), Date(timeIntervalSince1970: dSeventy3)])
-        XCTAssertEqual("\(dSeventy1),\(dSeventy2),\(dSeventy3)".dateArray1970M()!, [Date(timeIntervalSince1970: dSeventy1/1000), Date(timeIntervalSince1970: dSeventy2/1000), Date(timeIntervalSince1970: dSeventy3/1000)])
+        XCTAssertEqual("\(dSeventy1),\(dSeventy2),\(dSeventy3)".dateArray(decoderStrategy: .secondsSince1970)!, [Date(timeIntervalSince1970: dSeventy1), Date(timeIntervalSince1970: dSeventy2), Date(timeIntervalSince1970: dSeventy3)])
+        XCTAssertEqual("\(dSeventy1),\(dSeventy2),\(dSeventy3)".dateArray(decoderStrategy: .millisecondsSince1970)!, [Date(timeIntervalSince1970: dSeventy1/1000), Date(timeIntervalSince1970: dSeventy2/1000), Date(timeIntervalSince1970: dSeventy3/1000)])
         if #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
-        XCTAssertEqual("\(dISO1),\(dISO2),\(dISO3)".dateArrayISO()!, [_iso8601Formatter.date(from: dISO1)!, _iso8601Formatter.date(from: dISO2)!, _iso8601Formatter.date(from: dISO3)!])
+        XCTAssertEqual("\(dISO1),\(dISO2),\(dISO3)".dateArray(decoderStrategy: .iso8601)!, [_iso8601Formatter.date(from: dISO1)!, _iso8601Formatter.date(from: dISO2)!, _iso8601Formatter.date(from: dISO3)!])
         }
-        XCTAssertEqual("\(dDeferred1),\(dDeferred2),\(dDeferred3)".dateArrayDeferred()!, [Date(timeIntervalSinceReferenceDate: dDeferred1), Date(timeIntervalSinceReferenceDate: dDeferred2), Date(timeIntervalSinceReferenceDate: dDeferred3)])
+        XCTAssertEqual("\(dDeferred1),\(dDeferred2),\(dDeferred3)".dateArray(decoderStrategy: .deferredToDate)!, [Date(timeIntervalSinceReferenceDate: dDeferred1), Date(timeIntervalSinceReferenceDate: dDeferred2), Date(timeIntervalSinceReferenceDate: dDeferred3)])
     }
 }

--- a/Tests/KituraContractsTests/StringExtensionTests.swift
+++ b/Tests/KituraContractsTests/StringExtensionTests.swift
@@ -63,7 +63,7 @@ class StringExtensionsTests: XCTestCase {
         XCTAssertEqual("3.0".double, Double(3.0))
         XCTAssertEqual("4.0".float, Float(4.0))
         XCTAssertEqual("true".boolean, true)
-        XCTAssertEqual(d1.dateFormatted(fm), fm.date(from: d1))
+        XCTAssertEqual(d1.date(fm), fm.date(from: d1))
 
         let strArray = "string1,string2,string3"
         let intArray = "1,2,3"
@@ -84,7 +84,7 @@ class StringExtensionsTests: XCTestCase {
         XCTAssertEqual(pointIntArray.doubleArray!, [Double(1.0), Double(2.0), Double(3.0)])
         XCTAssertEqual(pointIntArray.floatArray!, [Float(1.0), Float(2.0), Float(3.0)])
         XCTAssertEqual("true,false,true".booleanArray!, [true, false, true])
-        XCTAssertEqual("\(d1),\(d2),\(d3)".dateArrayFormatted(fm)!, [fm.date(from: d1)!, fm.date(from: d2)!, fm.date(from: d3)!])
+        XCTAssertEqual("\(d1),\(d2),\(d3)".dateArray(fm)!, [fm.date(from: d1)!, fm.date(from: d2)!, fm.date(from: d3)!])
         XCTAssertEqual("\(dSeventy1),\(dSeventy2),\(dSeventy3)".dateArray1970()!, [Date(timeIntervalSince1970: dSeventy1), Date(timeIntervalSince1970: dSeventy2), Date(timeIntervalSince1970: dSeventy3)])
         XCTAssertEqual("\(dSeventy1),\(dSeventy2),\(dSeventy3)".dateArray1970M()!, [Date(timeIntervalSince1970: dSeventy1/1000), Date(timeIntervalSince1970: dSeventy2/1000), Date(timeIntervalSince1970: dSeventy3/1000)])
         if #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {

--- a/Tests/KituraContractsTests/StringExtensionTests.swift
+++ b/Tests/KituraContractsTests/StringExtensionTests.swift
@@ -36,6 +36,18 @@ class StringExtensionsTests: XCTestCase {
         let d2 = fm.string(from: Date())
         let d3 = fm.string(from: Date())
 
+        let dDeferred1 = 589714729.0
+        let dDeferred2 = 589714729.0
+        let dDeferred3 = 589714729.0
+
+        let dSeventy1 = 1567684372.0
+        let dSeventy2 = 1567684372.0
+        let dSeventy3 = 1567684372.0
+
+        let dISO1 = "2019-09-06T10:14:41+0000"
+        let dISO2 = "2019-09-06T10:14:41+0000"
+        let dISO3 = "2019-09-06T10:14:41+0000"
+
         /// Assert object string -> T conversion
         XCTAssertEqual("string".string, "string")
         XCTAssertEqual("1".int, Int(1))
@@ -72,6 +84,12 @@ class StringExtensionsTests: XCTestCase {
         XCTAssertEqual(pointIntArray.doubleArray!, [Double(1.0), Double(2.0), Double(3.0)])
         XCTAssertEqual(pointIntArray.floatArray!, [Float(1.0), Float(2.0), Float(3.0)])
         XCTAssertEqual("true,false,true".booleanArray!, [true, false, true])
-        XCTAssertEqual("\(d1),\(d2),\(d3)".dateArray(fm)!, [fm.date(from: d1)!, fm.date(from: d2)!, fm.date(from: d3)!])
+        XCTAssertEqual("\(d1),\(d2),\(d3)".dateArrayFormatted(fm)!, [fm.date(from: d1)!, fm.date(from: d2)!, fm.date(from: d3)!])
+        XCTAssertEqual("\(dSeventy1),\(dSeventy2),\(dSeventy3)".dateArray1970(), [Date(timeIntervalSince1970: dSeventy1), Date(timeIntervalSince1970: dSeventy2), Date(timeIntervalSince1970: dSeventy3)])
+        XCTAssertEqual("\(dSeventy1),\(dSeventy2),\(dSeventy3)".dateArray1970M(), [Date(timeIntervalSince1970: dSeventy1/1000), Date(timeIntervalSince1970: dSeventy2/1000), Date(timeIntervalSince1970: dSeventy3/1000)])
+        if #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
+        XCTAssertEqual("\(dISO1),\(dISO2),\(dISO3)".dateArrayISO(), [_iso8601Formatter.date(from: dISO1)!, _iso8601Formatter.date(from: dISO2)!, _iso8601Formatter.date(from: dISO3)!])
+        }
+        XCTAssertEqual("\(dDeferred1),\(dDeferred2),\(dDeferred3)".dateArrayDeferred(), [Date(timeIntervalSinceReferenceDate: dDeferred1), Date(timeIntervalSinceReferenceDate: dDeferred2), Date(timeIntervalSinceReferenceDate: dDeferred3)])
     }
 }


### PR DESCRIPTION
Both QueryEncoder and QueryDecoder now have support for more than just the default formatting, now supports: ISO8601, Custom, Formatting, Date Deferred To and Time Interval Since 1970.

Resolves #41 