### PR TITLE
[Issue-65] Update deployment target versions & update LoggerAPI to 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,11 @@
 .DS_Store
-/build/*
-/.build/*
 /.build-ubuntu/*
 /*.xcodeproj
-Package.resolved
 
 # Swift Package Manager
 #
-# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
-# Packages/
-.build/
-.swiftpm
+/Packages
+/Package.resolved
+/build
+/.build
+/.swiftpm

--- a/KituraContracts.podspec
+++ b/KituraContracts.podspec
@@ -1,17 +1,29 @@
-
 Pod::Spec.new do |s|
-  s.name        = "KituraContracts"
-  s.version     = "2.0.1"
-  s.summary     = "KituraContracts is a library containing type definitions shared by client and server code."
-  s.homepage    = "https://github.com/Kitura/KituraContracts"
-  s.license     = { :type => "Apache License, Version 2.0" }
-  s.author     = "IBM"
-  s.module_name  = 'KituraContracts'
-  s.osx.deployment_target = "10.11"
-  s.ios.deployment_target = "10.0"
-  s.tvos.deployment_target = "9.1"
-  s.watchos.deployment_target = "2.0"
-  s.source   = { :git => "https://github.com/Kitura/KituraContracts.git", :tag => s.version }
-  s.source_files = "Sources/**/*.swift"
-  s.dependency 'LoggerAPI', '~> 1.9'
+
+  s.name              = "KituraContracts"
+  s.module_name       = 'KituraContracts'
+  s.version           = "2.0.1"
+  s.cocoapods_version = '~> 1.16'
+  s.summary           = "KituraContracts is a library containing type definitions shared by client and server code."
+  s.homepage          = "https://github.com/Kitura/KituraContracts"
+  s.license           = {
+                          :type => "Apache License, Version 2.0"
+                        }
+  s.source            = {
+                          :git => "https://github.com/Kitura/KituraContracts.git",
+                          :tag => s.version
+                        }
+  s.author            = "IBM"
+
+  s.swift_version = '5.8'
+
+  s.ios.deployment_target = "12.0"
+  s.osx.deployment_target = "11.0"
+  s.tvos.deployment_target = "12.0"
+  s.watchos.deployment_target = "8.0"
+
+  s.source_files      = "Sources/**/*.swift"
+
+  s.dependency 'LoggerAPI', '~> 2.0'
+
 end


### PR DESCRIPTION
* Update minimum deployment target versions to support current build tooling
* Update swift version to 5.8
* Update LoggerAPI version to 2.0

### Dependencies
* Kitura/LoggerAPI#63
* Full publishing of `SwiftlyLogging` pod
  * https://cocoapods.org/pods/SwiftlyLogging
  * https://github.com/CocoaPods/Specs/tree/master/Specs/7/6/8/SwiftlyLogging
  * Currently seems to be published...but `pod repo update` isn't pulling it down